### PR TITLE
Switch from JLC04161H-2116D to JLC04161H-7628 stackup

### DIFF
--- a/ADF4158_PCB.kicad_pcb
+++ b/ADF4158_PCB.kicad_pcb
@@ -3,7 +3,7 @@
 	(generator "pcbnew")
 	(generator_version "9.0")
 	(general
-		(thickness 1.4996)
+		(thickness 1.6166)
 		(legacy_teardrops no)
 	)
 	(paper "A4")
@@ -63,15 +63,10 @@
 			(layer "dielectric 1"
 				(type "prepreg")
 				(color "FR4 natural")
-				(thickness 0.124)
-				(material "2116")
-				(epsilon_r 4.16)
-				(loss_tangent 0.02) addsublayer
-				(color "FR4 natural")
 				(thickness 0.2104)
 				(material "7628")
 				(epsilon_r 4.4)
-				(loss_tangent 0)
+				(loss_tangent 0.02)
 			)
 			(layer "In1.Cu"
 				(type "copper")
@@ -80,7 +75,7 @@
 			(layer "dielectric 2"
 				(type "core")
 				(color "FR4 natural")
-				(thickness 0.7)
+				(thickness 1.065)
 				(material "FR4")
 				(epsilon_r 4.5)
 				(loss_tangent 0.02)
@@ -95,12 +90,7 @@
 				(thickness 0.2104)
 				(material "7628")
 				(epsilon_r 4.4)
-				(loss_tangent 0.02) addsublayer
-				(color "FR4 natural")
-				(thickness 0.124)
-				(material "2116")
-				(epsilon_r 4.16)
-				(loss_tangent 0)
+				(loss_tangent 0.02)
 			)
 			(layer "B.Cu"
 				(type "copper")
@@ -1009,7 +999,7 @@
 				(max_width 2)
 				(curved_edges no)
 				(filter_ratio 0.9)
-				(enabled yes)
+				(enabled no)
 				(allow_two_segments yes)
 				(prefer_zone_connections yes)
 			)
@@ -13785,6 +13775,17 @@
 			(net 16 "/rf_out")
 			(pinfunction "In")
 			(pintype "passive")
+			(teardrops
+				(best_length_ratio 0.5)
+				(max_length 1)
+				(best_width_ratio 1)
+				(max_width 2)
+				(curved_edges no)
+				(filter_ratio 0.9)
+				(enabled yes)
+				(allow_two_segments yes)
+				(prefer_zone_connections yes)
+			)
 			(uuid "31250440-efe7-47e5-8cf2-cf1b00f2fc14")
 		)
 		(pad "2" smd rect
@@ -23275,254 +23276,234 @@
 		(uuid "fdc96a59-c299-4c64-8233-96887194cfd0")
 	)
 	(gr_line
-		(start 214.999998 15)
-		(end 214.999998 73.398)
+		(start 155.5 38.338)
+		(end 278.828575 38.338)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "0243041f-40a9-4173-ae08-bb090d14b2ac")
+		(uuid "0d463206-dc52-4e11-a5b2-496d79c56f8a")
 	)
 	(gr_line
-		(start 150 15)
-		(end 281.37143 15)
+		(start 261.871431 16)
+		(end 261.871431 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "0bd47c98-664c-4ac6-ae24-fe116c85bd27")
+		(uuid "11751c9a-e71a-47a8-bb94-05e90868b334")
 	)
 	(gr_line
-		(start 150 30.126)
-		(end 281.37143 30.126)
+		(start 155.5 52.762)
+		(end 278.828575 52.762)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "109631b9-8300-4a17-ab40-0dc10082d174")
+		(uuid "138fd769-5f63-440c-9a8c-c779196af7cc")
 	)
 	(gr_line
-		(start 173.428569 15)
-		(end 173.428569 73.398)
+		(start 155.5 34.732)
+		(end 278.828575 34.732)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "10ee5e6e-c75e-41ce-81e4-364a72b5d947")
+		(uuid "1db1a463-a67e-4961-b4f7-d0b1478dd848")
 	)
 	(gr_line
-		(start 281.37143 15)
-		(end 281.37143 73.398)
+		(start 155.5 16)
+		(end 278.828575 16)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "356fbac4-af33-4639-87e1-0ac0db1fef1c")
+		(uuid "20a6ef40-54f5-45ef-b706-a4f0706c7102")
 	)
 	(gr_line
-		(start 150 44.55)
-		(end 281.37143 44.55)
+		(start 155.5 41.944)
+		(end 278.828575 41.944)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "40c4191a-75be-4632-8d4e-bba861e0e0cc")
+		(uuid "357c8b7f-8236-4c85-9052-e43b11ab8f77")
 	)
 	(gr_line
-		(start 150 15)
-		(end 150 73.398)
+		(start 155.5 27.52)
+		(end 278.828575 27.52)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "43c45b96-adca-4aa6-915b-751fff33cb2c")
+		(uuid "37ff94e9-cfd2-4b7e-b0be-11347c47b4fe")
 	)
 	(gr_line
-		(start 150 26.52)
-		(end 281.37143 26.52)
+		(start 155.5 56.368)
+		(end 278.828575 56.368)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "4c3cefdb-c597-4a66-92ff-4e790545c70b")
+		(uuid "530bc064-c02c-4c44-90c1-c1d28fc38c5b")
 	)
 	(gr_line
-		(start 150 22.914)
-		(end 281.37143 22.914)
+		(start 155.5 49.156)
+		(end 278.828575 49.156)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "4fb4b91d-f1f7-40d0-b52b-661ed597e937")
+		(uuid "639794d5-0d67-4b66-893d-533702a3589d")
 	)
 	(gr_line
-		(start 198.499997 15)
-		(end 198.499997 73.398)
+		(start 155.5 20.308)
+		(end 278.828575 20.308)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "54fd2a9e-0b2c-482c-af0d-555111cf6421")
+		(uuid "66bf39b8-dffd-4931-a026-15c9600aabc1")
 	)
 	(gr_line
-		(start 251.528571 15)
-		(end 251.528571 73.398)
+		(start 155.5 59.974)
+		(end 278.828575 59.974)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "59923e04-0f66-4498-bfbf-8342cb6bd4f5")
+		(uuid "707e43f8-9f55-4276-b99f-d15b87fb9af9")
 	)
 	(gr_line
-		(start 150 33.732)
-		(end 281.37143 33.732)
+		(start 155.5 45.55)
+		(end 278.828575 45.55)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "6503b76f-da23-438f-8731-7a07a3f007fc")
+		(uuid "72eec5f4-3564-44fc-98e2-7a941b5420c3")
 	)
 	(gr_line
-		(start 150 62.58)
-		(end 281.37143 62.58)
+		(start 170.885714 16)
+		(end 170.885714 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "7c3f4dc6-5657-44b8-a450-0f342b216aa6")
+		(uuid "7f5b3101-5920-453c-a3c5-5b8ec57a1061")
 	)
 	(gr_line
-		(start 150 37.338)
-		(end 281.37143 37.338)
+		(start 155.5 31.126)
+		(end 278.828575 31.126)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "864b6671-aa20-400d-83e4-2d586a3879b7")
+		(uuid "83fb98ca-7210-44b6-b59c-45f60119a7cb")
 	)
 	(gr_line
-		(start 150 40.944)
-		(end 281.37143 40.944)
+		(start 155.5 67.186)
+		(end 278.828575 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "8b449b0f-8ea7-49e2-a83e-199515056624")
+		(uuid "9b8dde13-510a-44cd-92b4-e323843a14f7")
 	)
 	(gr_line
-		(start 150 58.974)
-		(end 281.37143 58.974)
+		(start 195.957142 16)
+		(end 195.957142 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "a2cec7ec-487a-441e-be7c-ca2f7aa6100a")
+		(uuid "b637b59c-ee4d-48a4-a91c-962043baa49f")
 	)
 	(gr_line
-		(start 264.414286 15)
-		(end 264.414286 73.398)
+		(start 232.485715 16)
+		(end 232.485715 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "ac686ce5-69d1-42e3-9d25-a4793a7776da")
+		(uuid "ccc1faae-5452-406f-8680-177d129c5b22")
 	)
 	(gr_line
-		(start 235.02857 15)
-		(end 235.02857 73.398)
+		(start 155.5 16)
+		(end 155.5 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "bc861206-6c30-434f-9fb0-a42da1833e3a")
+		(uuid "cde831a6-1d90-4e9e-a80d-c6f94439fc5e")
 	)
 	(gr_line
-		(start 150 51.762)
-		(end 281.37143 51.762)
+		(start 212.457143 16)
+		(end 212.457143 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "bdb4ec99-88bb-4bcd-b0eb-dc3494932974")
+		(uuid "d461e650-a856-410d-be79-96569b1c77c5")
 	)
 	(gr_line
-		(start 150 66.186)
-		(end 281.37143 66.186)
+		(start 155.5 63.58)
+		(end 278.828575 63.58)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "c084465d-93d2-45d8-8c54-e03c394291c6")
+		(uuid "db4e24da-73aa-47bb-86b9-4a7acf81252f")
 	)
 	(gr_line
-		(start 150 55.368)
-		(end 281.37143 55.368)
+		(start 248.985716 16)
+		(end 248.985716 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "c3440f41-60b8-43f2-92f0-819951d984f9")
+		(uuid "ec8ea5b9-29a8-40d6-bf56-9b990eb87550")
 	)
 	(gr_line
-		(start 150 19.308)
-		(end 281.37143 19.308)
+		(start 278.828575 16)
+		(end 278.828575 67.186)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "d2b3e15b-bfef-43be-b694-d2968496aa9b")
+		(uuid "edfb54ca-e2c1-4b3b-b4de-56880422d129")
 	)
 	(gr_line
-		(start 150 48.156)
-		(end 281.37143 48.156)
+		(start 155.5 23.914)
+		(end 278.828575 23.914)
 		(stroke
 			(width 0.1)
 			(type default)
 		)
 		(layer "Cmts.User")
-		(uuid "f17a7afe-5cbd-4659-ba1e-98f05f5ea0fd")
-	)
-	(gr_line
-		(start 150 69.792)
-		(end 281.37143 69.792)
-		(stroke
-			(width 0.1)
-			(type default)
-		)
-		(layer "Cmts.User")
-		(uuid "fb9a9b5f-a4c0-4878-abfe-e61fe631cbf3")
-	)
-	(gr_line
-		(start 150 73.398)
-		(end 281.37143 73.398)
-		(stroke
-			(width 0.1)
-			(type default)
-		)
-		(layer "Cmts.User")
-		(uuid "fbc9b37e-d6c1-4d37-85c0-997cbcd64e91")
+		(uuid "f8602c4c-824e-45de-a52e-17ea5fc6ac69")
 	)
 	(gr_rect
 		(start 122.5 88)
@@ -23559,22 +23540,22 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0 mm"
-		(at 215.749998 66.936 0)
+	(gr_text "Type"
+		(at 171.635714 16.75 0)
 		(layer "Cmts.User")
-		(uuid "026e4953-b8a6-4cab-a449-c42431eaeeb3")
+		(uuid "01688c22-7566-4faa-99d7-d469eaa6c1b2")
 		(effects
 			(font
 				(size 1.5 1.5)
-				(thickness 0.1)
+				(thickness 0.3)
 			)
 			(justify left top)
 		)
 	)
 	(gr_text ""
-		(at 235.77857 48.906 0)
+		(at 233.235715 24.664 0)
 		(layer "Cmts.User")
-		(uuid "0478b8a5-440b-4979-aa81-3b14f62dec32")
+		(uuid "01d1f9e6-98ea-4b52-939d-191f38c291da")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23583,10 +23564,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.02"
-		(at 265.164286 34.482 0)
+	(gr_text "FR4 natural"
+		(at 233.235715 49.906 0)
 		(layer "Cmts.User")
-		(uuid "04bd0d60-61d1-4887-870e-a639782e347a")
+		(uuid "022680d1-d839-4109-82f2-d911b9410d5f")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23595,10 +23576,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "F.Mask"
-		(at 150.75 27.27 0)
+	(gr_text "3.3"
+		(at 249.735716 57.118 0)
 		(layer "Cmts.User")
-		(uuid "07623b12-f460-44ad-a2ad-6a07e68b57df")
+		(uuid "030859e9-be11-42ac-a7b7-1b3b603bedc2")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23607,10 +23588,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text ""
-		(at 235.77857 59.724 0)
+	(gr_text "0.2104 mm"
+		(at 213.207143 35.482 0)
 		(layer "Cmts.User")
-		(uuid "07f46266-6e57-4493-bd72-f078c1f387cf")
+		(uuid "03c7ff3d-99b6-4018-a7d1-399b94751cb6")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23619,58 +23600,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text ""
-		(at 235.77857 41.694 0)
+	(gr_text "FR4"
+		(at 196.707142 42.694 0)
 		(layer "Cmts.User")
-		(uuid "088b8579-8766-4d06-8720-9488352bf119")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Not specified"
-		(at 235.77857 20.058 0)
-		(layer "Cmts.User")
-		(uuid "0a97649d-7857-4076-8e7b-006b21a27ab8")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "1"
-		(at 252.278571 20.058 0)
-		(layer "Cmts.User")
-		(uuid "0bdb43ef-db9e-4cfc-be2f-69651f74a460")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0.7 mm"
-		(at 215.749998 45.3 0)
-		(layer "Cmts.User")
-		(uuid "0d2f41e3-caca-43ec-ab2f-cf2d2594eb68")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0.0152 mm"
-		(at 215.749998 63.33 0)
-		(layer "Cmts.User")
-		(uuid "0e800c8b-7a00-4f40-9dfa-9e9b8f30aa75")
+		(uuid "081b8de1-98ce-4ec8-8a49-c755fa188009")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23680,9 +23613,9 @@
 		)
 	)
 	(gr_text "0"
-		(at 265.164286 66.936 0)
+		(at 262.621431 28.27 0)
 		(layer "Cmts.User")
-		(uuid "0f3024a5-04b8-4e5c-96ba-da03d33d2a93")
+		(uuid "0a088c05-2b0f-4065-966a-406508862878")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23691,10 +23624,34 @@
 			(justify left top)
 		)
 	)
-	(gr_text "1"
-		(at 252.278571 70.542 0)
+	(gr_text "Top Silk Screen"
+		(at 171.635714 21.058 0)
 		(layer "Cmts.User")
-		(uuid "1023b904-ecec-4f87-b5d0-ffa841e35817")
+		(uuid "0ae3316f-0ccc-40ff-8bad-72d96ed15f18")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "prepreg"
+		(at 171.635714 49.906 0)
+		(layer "Cmts.User")
+		(uuid "0b24fddd-1697-479d-9de5-36b6be2b6370")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "B.Silkscreen"
+		(at 156.25 64.33 0)
+		(layer "Cmts.User")
+		(uuid "10956ede-d92e-404c-abaa-86f63d848aa4")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23715,10 +23672,34 @@
 			(justify left top)
 		)
 	)
-	(gr_text "1"
-		(at 252.278571 23.664 0)
+	(gr_text "B.Mask"
+		(at 156.25 57.118 0)
 		(layer "Cmts.User")
-		(uuid "15fe9c30-9110-490c-bbdb-bcbb849ca7c0")
+		(uuid "143f4bf8-b146-4cbf-a4df-726297094628")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0"
+		(at 262.621431 57.118 0)
+		(layer "Cmts.User")
+		(uuid "14e96df1-d7fe-466d-8b4c-7bf458027bab")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "1.065 mm"
+		(at 213.207143 42.694 0)
+		(layer "Cmts.User")
+		(uuid "163c28e4-9ef5-4160-91b4-4d71e3e576b3")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23739,42 +23720,6 @@
 			(justify left top)
 		)
 	)
-	(gr_text "prepreg"
-		(at 174.178569 56.118 0)
-		(layer "Cmts.User")
-		(uuid "18cbf9f1-b535-4845-a317-0206a073816d")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "2116"
-		(at 199.249997 56.118 0)
-		(layer "Cmts.User")
-		(uuid "1abc9ecf-3c8c-4dd8-932f-927b65cae9a8")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0"
-		(at 265.164286 27.27 0)
-		(layer "Cmts.User")
-		(uuid "1af0ff19-e2e4-4244-9cae-0bcc2d691598")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
 	(gr_text "55.0000 mm x 25.0000 mm"
 		(at 51.407143 26.451 0)
 		(layer "Cmts.User")
@@ -23783,30 +23728,6 @@
 			(font
 				(size 1.5 1.5)
 				(thickness 0.2)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "FR4 natural"
-		(at 235.77857 45.3 0)
-		(layer "Cmts.User")
-		(uuid "1c71c70b-1f76-4cfa-8002-3bf4dbb0809e")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text ""
-		(at 235.77857 23.664 0)
-		(layer "Cmts.User")
-		(uuid "1ea03baf-6738-4f24-ba19-3112afbe94a6")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
 			)
 			(justify left top)
 		)
@@ -23823,10 +23744,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text ""
-		(at 199.249997 23.664 0)
+	(gr_text "copper"
+		(at 171.635714 46.3 0)
 		(layer "Cmts.User")
-		(uuid "1fc6bb38-9de2-45db-a6db-95681683aa09")
+		(uuid "22721b42-9410-448f-b8a3-87731847b93f")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23835,22 +23756,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.124 mm"
-		(at 215.749998 34.482 0)
+	(gr_text "Layer Name"
+		(at 156.25 16.75 0)
 		(layer "Cmts.User")
-		(uuid "22e914a9-c574-4879-a701-1a21c5eebb71")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Type"
-		(at 174.178569 15.75 0)
-		(layer "Cmts.User")
-		(uuid "26853140-84e7-4e4f-a61d-84516fcd80a2")
+		(uuid "24792378-d8a8-475a-8f15-329b96efd879")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23859,82 +23768,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0"
-		(at 265.164286 63.33 0)
+	(gr_text "Not specified"
+		(at 233.235715 28.27 0)
 		(layer "Cmts.User")
-		(uuid "26b63799-d94a-4efc-b866-4adca38d6dab")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "B.Paste"
-		(at 150.75 66.936 0)
-		(layer "Cmts.User")
-		(uuid "285f1a3c-95ed-46d9-aa60-afaf9ad34b2b")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0 mm"
-		(at 215.749998 70.542 0)
-		(layer "Cmts.User")
-		(uuid "2a68127a-c35b-4b13-b7fe-fd8ebd34985b")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "4.16"
-		(at 252.278571 34.482 0)
-		(layer "Cmts.User")
-		(uuid "2ba0321c-c7b9-493e-a5a4-35fd7804af1e")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0"
-		(at 265.164286 41.694 0)
-		(layer "Cmts.User")
-		(uuid "2d0a7acf-e40b-4796-b1da-d9fe187f6585")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "copper"
-		(at 174.178569 48.906 0)
-		(layer "Cmts.User")
-		(uuid "2d322b47-d4bb-447a-a23f-740395ca373b")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "F.Paste"
-		(at 150.75 23.664 0)
-		(layer "Cmts.User")
-		(uuid "2ffe51d2-ca96-495c-a608-0f955837ad44")
+		(uuid "251856b5-e6e1-4faf-a3c4-4d92ed48d2ba")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23944,9 +23781,9 @@
 		)
 	)
 	(gr_text "0.02"
-		(at 265.164286 52.512 0)
+		(at 262.621431 35.482 0)
 		(layer "Cmts.User")
-		(uuid "3034f5b6-60e2-4774-a381-2f5a2207e1db")
+		(uuid "28051639-5fb8-4a04-8103-adff39b5a674")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23955,10 +23792,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Top Solder Mask"
-		(at 174.178569 27.27 0)
+	(gr_text "0 mm"
+		(at 213.207143 64.33 0)
 		(layer "Cmts.User")
-		(uuid "32b19890-8d5c-431b-bac4-3e751850825c")
+		(uuid "28aa159c-3b46-48c4-ab5a-d6cd66168db6")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23967,10 +23804,58 @@
 			(justify left top)
 		)
 	)
-	(gr_text "7628"
-		(at 199.249997 38.088 0)
+	(gr_text "1"
+		(at 249.735716 24.664 0)
 		(layer "Cmts.User")
-		(uuid "338be079-d41e-4fbb-b61c-0121d7ca9246")
+		(uuid "2aa280f1-e689-44aa-9f87-05330cd64611")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Not specified"
+		(at 196.707142 57.118 0)
+		(layer "Cmts.User")
+		(uuid "2ab1300d-dc8d-42ae-b74e-7b22e5fed7e9")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text ""
+		(at 196.707142 46.3 0)
+		(layer "Cmts.User")
+		(uuid "2bab699d-523f-4fc0-afde-6a31c38bd3fc")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0"
+		(at 262.621431 53.512 0)
+		(layer "Cmts.User")
+		(uuid "2e6d0dbf-8942-44e7-856d-995ca95f506c")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0"
+		(at 262.621431 39.088 0)
+		(layer "Cmts.User")
+		(uuid "35a63585-44c7-4dd2-ac14-c0d7e9024588")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -23991,6 +23876,42 @@
 			(justify left top)
 		)
 	)
+	(gr_text "1"
+		(at 249.735716 21.058 0)
+		(layer "Cmts.User")
+		(uuid "36db8638-730f-48b5-be1d-7830f53b8703")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "FR4 natural"
+		(at 233.235715 35.482 0)
+		(layer "Cmts.User")
+		(uuid "37b50787-c59d-44de-9b6c-71eeb8fa0a8b")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Not specified"
+		(at 233.235715 64.33 0)
+		(layer "Cmts.User")
+		(uuid "3811fe1c-c762-4525-ad28-6cabc3ec09fc")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
 	(gr_text "1.4996 mm"
 		(at 110.507138 22.494 0)
 		(layer "Cmts.User")
@@ -24003,10 +23924,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text ""
-		(at 235.77857 30.876 0)
+	(gr_text "0.0152 mm"
+		(at 213.207143 39.088 0)
 		(layer "Cmts.User")
-		(uuid "3a38d5f3-35ba-40a4-b7c7-708547f2973f")
+		(uuid "3ac016a3-18ca-44c6-ab0f-8d9ab5dad40b")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24015,10 +23936,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.035 mm"
-		(at 215.749998 30.876 0)
+	(gr_text "0.02"
+		(at 262.621431 42.694 0)
 		(layer "Cmts.User")
-		(uuid "3b5455ee-1569-4033-b52f-47c54e5e2508")
+		(uuid "3aca8424-fbff-4d89-b6b1-23e9aae66d68")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24027,82 +23948,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "In1.Cu"
-		(at 150.75 41.694 0)
+	(gr_text "B.Paste"
+		(at 156.25 60.724 0)
 		(layer "Cmts.User")
-		(uuid "3bafd540-9743-4676-9196-d1f5118494bb")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "1"
-		(at 252.278571 59.724 0)
-		(layer "Cmts.User")
-		(uuid "3d2be988-7636-436e-89b5-73dc79244fbf")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0"
-		(at 265.164286 59.724 0)
-		(layer "Cmts.User")
-		(uuid "40a5ac27-9802-44dc-a313-4bf55bb4309f")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "B.Silkscreen"
-		(at 150.75 70.542 0)
-		(layer "Cmts.User")
-		(uuid "484c232e-5c6e-4b54-98b5-252209a1830f")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0"
-		(at 265.164286 48.906 0)
-		(layer "Cmts.User")
-		(uuid "4f468c77-cdcf-4e6d-8761-38373e78b4fd")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "F.Cu"
-		(at 150.75 30.876 0)
-		(layer "Cmts.User")
-		(uuid "516be622-de0d-4468-a7fb-046631593f8c")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Not specified"
-		(at 235.77857 27.27 0)
-		(layer "Cmts.User")
-		(uuid "51a4cda3-d8e6-4eab-9180-5e6f956ad8b1")
+		(uuid "3d379a5e-4838-42ac-9849-0acacaf88e22")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24112,57 +23961,9 @@
 		)
 	)
 	(gr_text "1"
-		(at 252.278571 30.876 0)
+		(at 249.735716 39.088 0)
 		(layer "Cmts.User")
-		(uuid "5210621b-af0e-4883-856d-d9921d880ff1")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text ""
-		(at 199.249997 66.936 0)
-		(layer "Cmts.User")
-		(uuid "54dacf2d-44db-4faf-9b2e-5f21e9c25c1b")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "7628"
-		(at 199.249997 52.512 0)
-		(layer "Cmts.User")
-		(uuid "55c3b507-6624-4cb0-a7fe-d83b3ae70495")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Dielectric 1  (1/2)"
-		(at 150.75 34.482 0)
-		(layer "Cmts.User")
-		(uuid "564ef8a8-b67c-4ab7-b60b-df91757de4ba")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "3.3"
-		(at 252.278571 63.33 0)
-		(layer "Cmts.User")
-		(uuid "57647177-6356-4de2-ab84-a017c394941e")
+		(uuid "3ddb0579-d99d-4b81-95df-b81d20eb97af")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24172,9 +23973,9 @@
 		)
 	)
 	(gr_text "Not specified"
-		(at 199.249997 27.27 0)
+		(at 196.707142 21.058 0)
 		(layer "Cmts.User")
-		(uuid "58e2d06c-2bc7-4287-8275-75fb09670dcf")
+		(uuid "3f301d85-fa84-4c67-aa79-bed2b51f829c")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24183,10 +23984,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "4.4"
-		(at 252.278571 38.088 0)
+	(gr_text "F.Mask"
+		(at 156.25 28.27 0)
 		(layer "Cmts.User")
-		(uuid "60849fe7-e4af-40c5-aae1-af4e120b28e8")
+		(uuid "49d22d72-ae17-4f54-bf57-2fd30ca91cc3")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24196,21 +23997,9 @@
 		)
 	)
 	(gr_text ""
-		(at 199.249997 41.694 0)
+		(at 233.235715 60.724 0)
 		(layer "Cmts.User")
-		(uuid "67644962-9e91-4b22-aa67-03c4586a090e")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "B.Cu"
-		(at 150.75 59.724 0)
-		(layer "Cmts.User")
-		(uuid "6d706286-31b1-44e4-a63b-99af9d22f953")
+		(uuid "4e23cdce-bec4-43e6-976a-9576177d66f3")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24220,9 +24009,9 @@
 		)
 	)
 	(gr_text "Material"
-		(at 199.249997 15.75 0)
+		(at 196.707142 16.75 0)
 		(layer "Cmts.User")
-		(uuid "6f5ff140-e0ca-404a-b04b-a60ff9a7a981")
+		(uuid "4f676293-0c89-4b16-a45d-7d5026edb677")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24231,10 +24020,94 @@
 			(justify left top)
 		)
 	)
-	(gr_text "core"
-		(at 174.178569 45.3 0)
+	(gr_text "Dielectric 1"
+		(at 156.25 35.482 0)
 		(layer "Cmts.User")
-		(uuid "700f5212-e1f6-448e-9033-20aa8ba78641")
+		(uuid "52a755a1-5126-4f2c-8e8a-9f6f69c548c4")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text ""
+		(at 233.235715 46.3 0)
+		(layer "Cmts.User")
+		(uuid "53e7b481-d83f-41f2-b5c1-3900f87f714a")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "F.Silkscreen"
+		(at 156.25 21.058 0)
+		(layer "Cmts.User")
+		(uuid "5967c5f8-5b9b-4de8-9474-8329a7e162b7")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0.035 mm"
+		(at 213.207143 53.512 0)
+		(layer "Cmts.User")
+		(uuid "5bd8b67a-cef9-476f-9879-e001d391030f")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Bottom Solder Paste"
+		(at 171.635714 60.724 0)
+		(layer "Cmts.User")
+		(uuid "630a1e73-c4c1-46ce-8b2e-1c117b59b15e")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0"
+		(at 262.621431 24.664 0)
+		(layer "Cmts.User")
+		(uuid "6511cb94-8ad4-4d06-bfdf-7eb4d5442e85")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text ""
+		(at 196.707142 39.088 0)
+		(layer "Cmts.User")
+		(uuid "6d0f125d-3cf2-4b23-9479-034edfa7d93b")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "4.4"
+		(at 249.735716 49.906 0)
+		(layer "Cmts.User")
+		(uuid "6e2975c6-d283-4e8a-956d-50ee72c86807")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24255,10 +24128,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.0152 mm"
-		(at 215.749998 41.694 0)
+	(gr_text "prepreg"
+		(at 171.635714 35.482 0)
 		(layer "Cmts.User")
-		(uuid "7087eb2a-8164-49c0-b170-d02fc65a1f1b")
+		(uuid "7122486a-39ed-416c-b3bf-2ddc99758da3")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24267,10 +24140,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.124 mm"
-		(at 215.749998 56.118 0)
+	(gr_text "copper"
+		(at 171.635714 53.512 0)
 		(layer "Cmts.User")
-		(uuid "727e88b0-a654-4c2d-b735-6e790403068e")
+		(uuid "74019e7e-786c-4ed8-9440-d0d616df21af")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24279,10 +24152,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Dielectric 3  (1/2)"
-		(at 150.75 52.512 0)
+	(gr_text "copper"
+		(at 171.635714 31.876 0)
 		(layer "Cmts.User")
-		(uuid "73287c96-68a2-4c68-b442-06ee61527051")
+		(uuid "7641ea36-2cd3-415f-b8f5-19b168c15b33")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24291,22 +24164,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "2116"
-		(at 199.249997 34.482 0)
+	(gr_text "0 mm"
+		(at 213.207143 60.724 0)
 		(layer "Cmts.User")
-		(uuid "7880d1e3-15a1-47f9-9a9b-1988489cdddc")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Not specified"
-		(at 199.249997 63.33 0)
-		(layer "Cmts.User")
-		(uuid "790d50d7-5b6a-4c8a-97fc-4254f15474f0")
+		(uuid "78f51d45-5da4-4189-ba2b-08b1ffd9d128")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24316,9 +24177,21 @@
 		)
 	)
 	(gr_text "0"
-		(at 265.164286 56.118 0)
+		(at 262.621431 31.876 0)
 		(layer "Cmts.User")
-		(uuid "79a64c4a-46b2-4db1-b9dd-f21a94a8df02")
+		(uuid "798d0c67-45ba-4963-90e9-dd8ee6eec5e3")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0 mm"
+		(at 213.207143 21.058 0)
+		(layer "Cmts.User")
+		(uuid "7a255f76-1b89-4c7c-8687-3bdc77d67a39")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24339,10 +24212,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Dielectric 2"
-		(at 150.75 45.3 0)
+	(gr_text "0 mm"
+		(at 213.207143 24.664 0)
 		(layer "Cmts.User")
-		(uuid "7c52a853-46d1-4944-b241-fc042a4e8850")
+		(uuid "837af8f7-e27e-4504-82a8-da9972e3d94a")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24351,106 +24224,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "B.Mask"
-		(at 150.75 63.33 0)
+	(gr_text "4.4"
+		(at 249.735716 35.482 0)
 		(layer "Cmts.User")
-		(uuid "84366177-7fbf-48fd-b2a5-b8b4e6e56eb0")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Not specified"
-		(at 199.249997 70.542 0)
-		(layer "Cmts.User")
-		(uuid "845f43eb-5229-4b48-9b72-4a6556516f8a")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "FR4 natural"
-		(at 235.77857 38.088 0)
-		(layer "Cmts.User")
-		(uuid "8ac5d2c4-9f53-422d-8656-93465746b732")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "4.16"
-		(at 252.278571 56.118 0)
-		(layer "Cmts.User")
-		(uuid "8b6834f9-972f-4ba9-bbc6-6ec6670bb7fd")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Loss Tangent"
-		(at 265.164286 15.75 0)
-		(layer "Cmts.User")
-		(uuid "8b82daa9-f424-4ffb-9ead-acc6db380bc6")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.3)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Not specified"
-		(at 235.77857 70.542 0)
-		(layer "Cmts.User")
-		(uuid "8bf80720-b782-44c5-8b6d-241d65d0ece5")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0.2104 mm"
-		(at 215.749998 38.088 0)
-		(layer "Cmts.User")
-		(uuid "8fc5d96f-8afc-4093-a569-6dc6fa61145d")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "FR4 natural"
-		(at 235.77857 34.482 0)
-		(layer "Cmts.User")
-		(uuid "91738504-0570-4ac2-8a73-3a48f3734a47")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text ""
-		(at 199.249997 59.724 0)
-		(layer "Cmts.User")
-		(uuid "924d7ae3-9b4d-4e77-a440-f88a60131934")
+		(uuid "84f81bff-33ef-407b-a38e-b24595adea2e")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24460,13 +24237,97 @@
 		)
 	)
 	(gr_text "Thickness (mm)"
-		(at 215.749998 15.75 0)
+		(at 213.207143 16.75 0)
 		(layer "Cmts.User")
-		(uuid "93fddf8f-864a-4f74-b24f-f9ce6eae6913")
+		(uuid "8755c479-fa6b-47b3-845d-57fd8d4e2401")
 		(effects
 			(font
 				(size 1.5 1.5)
 				(thickness 0.3)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0.035 mm"
+		(at 213.207143 31.876 0)
+		(layer "Cmts.User")
+		(uuid "87c7419d-82a8-4c94-82aa-1397c6f51e49")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text ""
+		(at 196.707142 31.876 0)
+		(layer "Cmts.User")
+		(uuid "87e021be-84cd-4ac3-b017-3b45707a362f")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0.2104 mm"
+		(at 213.207143 49.906 0)
+		(layer "Cmts.User")
+		(uuid "8987cbdd-2f37-4e24-952a-df94a5597856")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "1"
+		(at 249.735716 53.512 0)
+		(layer "Cmts.User")
+		(uuid "8c3d1587-5e98-468c-9082-5295ca60eac6")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Not specified"
+		(at 196.707142 28.27 0)
+		(layer "Cmts.User")
+		(uuid "8d714505-4290-4e18-8890-dfef602fb2f6")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "In2.Cu"
+		(at 156.25 46.3 0)
+		(layer "Cmts.User")
+		(uuid "8e40d263-bb65-4599-8d39-0356850d2018")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0.0152 mm"
+		(at 213.207143 57.118 0)
+		(layer "Cmts.User")
+		(uuid "93af5d27-bc1e-4cd8-ac58-90212f08e659")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
 			)
 			(justify left top)
 		)
@@ -24483,10 +24344,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0 mm"
-		(at 215.749998 23.664 0)
+	(gr_text ""
+		(at 196.707142 60.724 0)
 		(layer "Cmts.User")
-		(uuid "963b8b01-8759-4516-a27a-8a53eab42ee9")
+		(uuid "95328c4a-a9eb-46ef-a096-fbc5b8407e7b")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24495,10 +24356,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "1"
-		(at 252.278571 48.906 0)
+	(gr_text ""
+		(at 233.235715 53.512 0)
 		(layer "Cmts.User")
-		(uuid "96c3fab9-8604-4cf2-88f4-b411dfcecae4")
+		(uuid "977d9a05-7ee6-478a-b0a1-553379619b50")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24519,22 +24380,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Top Silk Screen"
-		(at 174.178569 20.058 0)
+	(gr_text "Not specified"
+		(at 233.235715 57.118 0)
 		(layer "Cmts.User")
-		(uuid "9a078920-6aa7-472d-bfed-3676b4888ba6")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "FR4 natural"
-		(at 235.77857 52.512 0)
-		(layer "Cmts.User")
-		(uuid "9c79315a-6bdc-4011-b669-30b9137949e3")
+		(uuid "9ccb3918-614d-4835-b181-5e893cfac0c7")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24555,10 +24404,46 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Top Solder Paste"
-		(at 174.178569 23.664 0)
+	(gr_text ""
+		(at 233.235715 39.088 0)
 		(layer "Cmts.User")
-		(uuid "a47d0021-cdf5-48ee-bd3b-7200c76394ba")
+		(uuid "9ff859f0-fd2e-4bc4-8b8c-ccf84857f69d")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Bottom Solder Mask"
+		(at 171.635714 57.118 0)
+		(layer "Cmts.User")
+		(uuid "a0112e2f-eb91-41d3-a2e0-28f7acd675a1")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "core"
+		(at 171.635714 42.694 0)
+		(layer "Cmts.User")
+		(uuid "a31a4ba2-e983-46fe-b296-8ee88132d070")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "1"
+		(at 249.735716 31.876 0)
+		(layer "Cmts.User")
+		(uuid "a3e561ac-63d5-4acd-9f3e-fa2dfb3760a5")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24579,46 +24464,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "3.3"
-		(at 252.278571 27.27 0)
+	(gr_text "0"
+		(at 262.621431 46.3 0)
 		(layer "Cmts.User")
-		(uuid "a5ad1192-68aa-43fb-a0cf-29f37b159dc9")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "copper"
-		(at 174.178569 41.694 0)
-		(layer "Cmts.User")
-		(uuid "a6185438-fb6d-4cb0-b528-caad324713f6")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text ""
-		(at 199.249997 30.876 0)
-		(layer "Cmts.User")
-		(uuid "a703c4f4-4f44-490b-8d97-ac1bed571502")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0.035 mm"
-		(at 215.749998 59.724 0)
-		(layer "Cmts.User")
-		(uuid "a8202641-0a0f-4dd2-882e-460e2b23e07d")
+		(uuid "a5f90c71-2c71-4502-95ca-68363a556090")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24639,26 +24488,26 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0 mm"
-		(at 215.749998 20.058 0)
+	(gr_text "Color"
+		(at 233.235715 16.75 0)
 		(layer "Cmts.User")
-		(uuid "afc33a24-8927-4163-92c9-7d354cd4fe0d")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Epsilon R"
-		(at 252.278571 15.75 0)
-		(layer "Cmts.User")
-		(uuid "b16f9c6f-5089-4608-a80b-9da97bc30b4b")
+		(uuid "ab0ce3af-a4d2-4c11-b132-47020fc90b29")
 		(effects
 			(font
 				(size 1.5 1.5)
 				(thickness 0.3)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "In1.Cu"
+		(at 156.25 39.088 0)
+		(layer "Cmts.User")
+		(uuid "b1141dcb-165c-4bfe-ad53-629a57d59e32")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
 			)
 			(justify left top)
 		)
@@ -24675,34 +24524,46 @@
 			(justify left top)
 		)
 	)
+	(gr_text "0.0152 mm"
+		(at 213.207143 46.3 0)
+		(layer "Cmts.User")
+		(uuid "b2776448-0f09-427e-a3eb-bb568247929c")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "B.Cu"
+		(at 156.25 53.512 0)
+		(layer "Cmts.User")
+		(uuid "b5d96b2f-b4ea-4c0e-9d13-26bee39fe2bc")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "1"
+		(at 249.735716 64.33 0)
+		(layer "Cmts.User")
+		(uuid "b5f437f1-f289-4dea-b689-99a94ecb57a8")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
 	(gr_text "Not specified"
-		(at 235.77857 63.33 0)
+		(at 196.707142 64.33 0)
 		(layer "Cmts.User")
-		(uuid "b4002845-29b8-4a1b-901c-a20064979814")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "F.Silkscreen"
-		(at 150.75 20.058 0)
-		(layer "Cmts.User")
-		(uuid "b76c58b1-d0dc-4abf-85db-14de33c78140")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "prepreg"
-		(at 174.178569 52.512 0)
-		(layer "Cmts.User")
-		(uuid "b8b70d8d-caa0-4819-a683-810561d9ba99")
+		(uuid "b7b62ffc-9a9d-4289-ba71-6a43cdd8fe44")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24723,6 +24584,30 @@
 			(justify left top)
 		)
 	)
+	(gr_text "F.Cu"
+		(at 156.25 31.876 0)
+		(layer "Cmts.User")
+		(uuid "bb069781-cef8-4516-8822-7a0ce2762ca3")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "FR4 natural"
+		(at 233.235715 42.694 0)
+		(layer "Cmts.User")
+		(uuid "bebde2b3-e370-4358-a67c-f509a2eec055")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
 	(gr_text "Board Thickness: "
 		(at 85.564281 22.494 0)
 		(layer "Cmts.User")
@@ -24735,10 +24620,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "prepreg"
-		(at 174.178569 38.088 0)
+	(gr_text "1"
+		(at 249.735716 46.3 0)
 		(layer "Cmts.User")
-		(uuid "c1edec57-fc78-45ba-9d86-fcacfc40cb31")
+		(uuid "c019830a-5f5a-4c37-9e65-dfb50f22f815")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24747,10 +24632,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "4.5"
-		(at 252.278571 45.3 0)
+	(gr_text ""
+		(at 196.707142 24.664 0)
 		(layer "Cmts.User")
-		(uuid "c28f0d9d-af44-4d81-ad66-1f3ed36c959c")
+		(uuid "c0b61dcd-b64a-4197-baa0-f81a74af602b")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24759,10 +24644,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "In2.Cu"
-		(at 150.75 48.906 0)
+	(gr_text "Bottom Silk Screen"
+		(at 171.635714 64.33 0)
 		(layer "Cmts.User")
-		(uuid "c408d91d-83ae-4645-8ac9-331d48437f5d")
+		(uuid "c30759ed-9b15-497e-b891-70f0b6c3ad75")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24771,10 +24656,82 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Dielectric 1  (1/2)"
-		(at 150.75 38.088 0)
+	(gr_text "Not specified"
+		(at 233.235715 21.058 0)
 		(layer "Cmts.User")
-		(uuid "c626d458-a2aa-4e48-9ef9-467cb3f260a3")
+		(uuid "c3949f21-22f6-4f96-8b56-f5f5cf0fdf52")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Dielectric 2"
+		(at 156.25 42.694 0)
+		(layer "Cmts.User")
+		(uuid "c82fb37d-c27c-4b68-a968-bbf96274d859")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Dielectric 3"
+		(at 156.25 49.906 0)
+		(layer "Cmts.User")
+		(uuid "c85ec428-cb05-404a-af3d-b80d32788f75")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0.0152 mm"
+		(at 213.207143 28.27 0)
+		(layer "Cmts.User")
+		(uuid "c8667fee-cf31-47e1-bc4b-abf45d6dc46d")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "Loss Tangent"
+		(at 262.621431 16.75 0)
+		(layer "Cmts.User")
+		(uuid "c8a104d8-79ff-4872-8e8f-d82aa9cbedfe")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.3)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text ""
+		(at 233.235715 31.876 0)
+		(layer "Cmts.User")
+		(uuid "c9ef9015-89e0-4e7b-82c8-74196372535c")
+		(effects
+			(font
+				(size 1.5 1.5)
+				(thickness 0.1)
+			)
+			(justify left top)
+		)
+	)
+	(gr_text "0.02"
+		(at 262.621431 49.906 0)
+		(layer "Cmts.User")
+		(uuid "cb8512d4-87f8-4574-8699-0db4fbbedf68")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24784,33 +24741,9 @@
 		)
 	)
 	(gr_text "0"
-		(at 265.164286 23.664 0)
+		(at 262.621431 60.724 0)
 		(layer "Cmts.User")
-		(uuid "cb3d5a18-0c3c-4a26-92ad-4174f3cb3d22")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Color"
-		(at 235.77857 15.75 0)
-		(layer "Cmts.User")
-		(uuid "cc4c3278-824a-43b9-87a2-0c17c6c5d6f4")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.3)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "4.4"
-		(at 252.278571 52.512 0)
-		(layer "Cmts.User")
-		(uuid "cdfdf9d1-0ae6-4e26-bc20-dd92c62f05da")
+		(uuid "ce460634-bb8e-4e89-bf35-3957cfabf094")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24831,22 +24764,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "1"
-		(at 252.278571 41.694 0)
-		(layer "Cmts.User")
-		(uuid "d29ea6ee-0c03-4646-9604-581dc6ac9168")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
 	(gr_text ""
-		(at 199.249997 48.906 0)
+		(at 196.707142 53.512 0)
 		(layer "Cmts.User")
-		(uuid "d33ad7e7-3182-46e7-a79f-3dbbaee1e3bb")
+		(uuid "d6ea827b-8cf3-48d1-a07e-76c362eda1d4")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24855,10 +24776,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.0152 mm"
-		(at 215.749998 48.906 0)
+	(gr_text "Top Solder Mask"
+		(at 171.635714 28.27 0)
 		(layer "Cmts.User")
-		(uuid "d44994c8-c225-416c-988f-09b20b88654a")
+		(uuid "d90437ad-7ccb-425b-b162-4505f0c6049d")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24867,10 +24788,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.0152 mm"
-		(at 215.749998 27.27 0)
+	(gr_text "4.5"
+		(at 249.735716 42.694 0)
 		(layer "Cmts.User")
-		(uuid "d504eaaf-4ea6-4e34-ac76-cfed6866cc42")
+		(uuid "d927aa6c-236d-4350-b4a2-1880fdc26b45")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24879,10 +24800,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Not specified"
-		(at 199.249997 20.058 0)
+	(gr_text "Top Solder Paste"
+		(at 171.635714 24.664 0)
 		(layer "Cmts.User")
-		(uuid "d685f77f-1d1d-4cb6-8669-04df60a0e9ea")
+		(uuid "da69f97d-cc71-4ad3-bbab-7a5b5a2f6b47")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24892,9 +24813,9 @@
 		)
 	)
 	(gr_text "1"
-		(at 252.278571 66.936 0)
+		(at 249.735716 60.724 0)
 		(layer "Cmts.User")
-		(uuid "d7ffad51-0bf0-4d6e-9fe8-312f08f73fb7")
+		(uuid "e225242a-aee0-40b3-9f7a-26eca0bfd664")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24903,34 +24824,22 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.2104 mm"
-		(at 215.749998 52.512 0)
+	(gr_text "Epsilon R"
+		(at 249.735716 16.75 0)
 		(layer "Cmts.User")
-		(uuid "dd193e9e-49c3-470d-b635-c4128ebe2cbc")
+		(uuid "e56f20d1-8d49-4f94-b494-50f3a84a1e3e")
 		(effects
 			(font
 				(size 1.5 1.5)
-				(thickness 0.1)
+				(thickness 0.3)
 			)
 			(justify left top)
 		)
 	)
-	(gr_text "0"
-		(at 265.164286 70.542 0)
+	(gr_text "copper"
+		(at 171.635714 39.088 0)
 		(layer "Cmts.User")
-		(uuid "e019bc0d-a0a0-43be-8a58-b36019f18c0f")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "prepreg"
-		(at 174.178569 34.482 0)
-		(layer "Cmts.User")
-		(uuid "e10a8425-1038-46cf-817f-8d1943586e8f")
+		(uuid "e7e0d876-5d14-4d4d-995a-3e6399ef4d56")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24940,45 +24849,9 @@
 		)
 	)
 	(gr_text "0"
-		(at 265.164286 38.088 0)
+		(at 262.621431 21.058 0)
 		(layer "Cmts.User")
-		(uuid "e1b97d7b-dd95-4110-a532-c9d31944cd21")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Bottom Solder Paste"
-		(at 174.178569 66.936 0)
-		(layer "Cmts.User")
-		(uuid "e3a93dc0-36d9-4730-8067-bae036b8095d")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text ""
-		(at 235.77857 66.936 0)
-		(layer "Cmts.User")
-		(uuid "e5108e22-917a-4e2b-877d-c27f4f53ae94")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0"
-		(at 265.164286 20.058 0)
-		(layer "Cmts.User")
-		(uuid "e84f91e1-20f9-40f7-ba83-9e24e78d25fa")
+		(uuid "e98ecbe2-50f5-4e71-b85d-bb13885f76f9")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -24995,18 +24868,6 @@
 			(font
 				(size 1.5 1.5)
 				(thickness 0.2)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "copper"
-		(at 174.178569 30.876 0)
-		(layer "Cmts.User")
-		(uuid "ea804705-8ab9-4350-911d-3da219b26bca")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
 			)
 			(justify left top)
 		)
@@ -25035,10 +24896,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Bottom Solder Mask"
-		(at 174.178569 63.33 0)
+	(gr_text "0"
+		(at 262.621431 64.33 0)
 		(layer "Cmts.User")
-		(uuid "ef6f91b4-e2ba-4b00-86bf-653b9eb88de8")
+		(uuid "ee6fe94a-200e-4cfb-bc55-38ebe82c335f")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -25059,10 +24920,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Bottom Silk Screen"
-		(at 174.178569 70.542 0)
+	(gr_text "7628"
+		(at 196.707142 49.906 0)
 		(layer "Cmts.User")
-		(uuid "f2a857c8-76e7-4849-8cdc-a5cccf73805a")
+		(uuid "f16c3617-1061-45b4-8117-664e6cb87e95")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -25071,10 +24932,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "FR4 natural"
-		(at 235.77857 56.118 0)
+	(gr_text "7628"
+		(at 196.707142 35.482 0)
 		(layer "Cmts.User")
-		(uuid "f2dea757-c30e-4197-a0e0-30a93e9dad0f")
+		(uuid "f5ca5c39-47da-4ead-8a39-9a0ba497901c")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -25083,22 +24944,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "Layer Name"
-		(at 150.75 15.75 0)
+	(gr_text "3.3"
+		(at 249.735716 28.27 0)
 		(layer "Cmts.User")
-		(uuid "f541dd92-ecab-4c0a-84ce-1662dbae03fa")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.3)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "copper"
-		(at 174.178569 59.724 0)
-		(layer "Cmts.User")
-		(uuid "f779ea51-dae1-47de-a326-c62aa010fb1f")
+		(uuid "f873cc56-7fb2-462b-ab8f-0264541bd686")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -25107,22 +24956,10 @@
 			(justify left top)
 		)
 	)
-	(gr_text "0.02"
-		(at 265.164286 45.3 0)
+	(gr_text "F.Paste"
+		(at 156.25 24.664 0)
 		(layer "Cmts.User")
-		(uuid "fa47adbc-b798-4adf-85ec-2227d619b281")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "0"
-		(at 265.164286 30.876 0)
-		(layer "Cmts.User")
-		(uuid "fc0a2209-c546-4cd5-8d89-2e246a096edb")
+		(uuid "f9059593-0cca-44e6-a013-c8f57f8aa5cf")
 		(effects
 			(font
 				(size 1.5 1.5)
@@ -25139,30 +24976,6 @@
 			(font
 				(size 1.5 1.5)
 				(thickness 0.2)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "Dielectric 3  (1/2)"
-		(at 150.75 56.118 0)
-		(layer "Cmts.User")
-		(uuid "ff39d373-15ee-4dca-b0c5-4ffc487efbdd")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
-			)
-			(justify left top)
-		)
-	)
-	(gr_text "FR4"
-		(at 199.249997 45.3 0)
-		(layer "Cmts.User")
-		(uuid "ff3a48f2-c25b-4187-b75e-57b705fb1c54")
-		(effects
-			(font
-				(size 1.5 1.5)
-				(thickness 0.1)
 			)
 			(justify left top)
 		)
@@ -29539,7 +29352,7 @@
 	(segment
 		(start 132.826292 105.226292)
 		(end 133.925 106.325)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "1752a3bd-ac7d-497f-a3e8-9150f9faa65c")
@@ -29547,7 +29360,7 @@
 	(segment
 		(start 147.48 105.48)
 		(end 150 102.96)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "3081b9fd-85d1-4a11-80fc-5c1b3b7626e8")
@@ -29555,7 +29368,7 @@
 	(segment
 		(start 137.968807 108)
 		(end 141.396181 108)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "a582d473-2d96-4a45-bc09-0bdc766c7161")
@@ -29563,7 +29376,7 @@
 	(segment
 		(start 132.25 103.835)
 		(end 132.25 103.02)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "f489c3df-df3b-4e8a-919f-8922057f37ed")
@@ -29572,7 +29385,7 @@
 		(start 132.25 103.835)
 		(mid 132.399773 104.587961)
 		(end 132.826292 105.226292)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "571b64be-a684-4802-98fd-5ab32e342d40")
@@ -29581,7 +29394,7 @@
 		(start 147.48 105.48)
 		(mid 144.68872 107.345073)
 		(end 141.396181 108)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "a42f4452-9e81-400f-87b7-d6354703d4d4")
@@ -29590,7 +29403,7 @@
 		(start 133.925 106.325)
 		(mid 135.780314 107.564681)
 		(end 137.968807 108)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 10)
 		(uuid "b7d769e3-418f-4b73-925c-0dad1e13e717")
@@ -29897,7 +29710,7 @@
 	(segment
 		(start 138.025 101.9875)
 		(end 136.7625 101.9875)
-		(width 0.3)
+		(width 0.33)
 		(layer "F.Cu")
 		(net 15)
 		(uuid "86e7f158-c734-4f55-bf6f-4b829e3de84e")
@@ -29913,7 +29726,7 @@
 	(segment
 		(start 127.78 102)
 		(end 123.625 102)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 16)
 		(uuid "92ab1a42-146c-459f-9e37-b64c8e9fe118")
@@ -29921,7 +29734,7 @@
 	(segment
 		(start 134.51 102)
 		(end 134.5 102.01)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 17)
 		(uuid "d588252a-a61e-4249-bb00-9a78ab839831")
@@ -29929,7 +29742,7 @@
 	(segment
 		(start 135.79 102)
 		(end 134.51 102)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 17)
 		(uuid "e2f06916-1cf9-4cd8-9546-712ef49b7e33")
@@ -29937,7 +29750,7 @@
 	(segment
 		(start 128.75 102.01)
 		(end 128.74 102)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 18)
 		(uuid "04c9684f-0c5b-4f44-a564-6aca8d964a87")
@@ -29945,7 +29758,7 @@
 	(segment
 		(start 129.99 102.01)
 		(end 128.75 102.01)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 18)
 		(uuid "d7ea31d3-16f7-45ad-b894-6e536495d8d9")
@@ -30845,7 +30658,7 @@
 	(segment
 		(start 133.48 102.01)
 		(end 132.26 102.01)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 44)
 		(uuid "71b8e884-2551-440e-ba47-9e20459ec6dc")
@@ -30853,7 +30666,7 @@
 	(segment
 		(start 132.26 102.01)
 		(end 132.25 102)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 44)
 		(uuid "a36149ce-221b-49d4-9227-3a24168b15c8")
@@ -30861,7 +30674,7 @@
 	(segment
 		(start 132.25 102)
 		(end 131.02 102)
-		(width 0.5906)
+		(width 0.3658)
 		(layer "F.Cu")
 		(net 44)
 		(uuid "e76fd33c-73f6-49d5-b706-cfeced8b9bf1")
@@ -31083,45 +30896,6 @@
 		(uuid "f2572361-a43d-40d5-be57-c260c38d9549")
 	)
 	(zone
-		(net 15)
-		(net_name "Net-(U4-RFOUT)")
-		(layer "F.Cu")
-		(uuid "08bf9faa-c786-43ef-9d2c-227430ddf71a")
-		(name "$teardrop_padvia$")
-		(hatch full 0.1)
-		(priority 30000)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 137.59 102.1375) (xy 137.59 101.8375) (xy 136.967615 101.716719) (xy 136.749 102) (xy 136.977562 102.276633)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 136.974694 101.718092) (xy 137.580529 101.835662) (xy 137.587998 101.840602) (xy 137.59 101.847148)
-				(xy 137.59 102.12816) (xy 137.586573 102.136433) (xy 137.580892 102.139569) (xy 136.984586 102.275037)
-				(xy 136.975759 102.273528) (xy 136.972974 102.27108) (xy 136.754951 102.007203) (xy 136.752324 101.998643)
-				(xy 136.754708 101.992603) (xy 136.963207 101.72243) (xy 136.970974 101.717975)
-			)
-		)
-	)
-	(zone
 		(net 2)
 		(net_name "GND")
 		(layer "F.Cu")
@@ -31149,125 +30923,186 @@
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 130.563117 102.748869) (xy 130.620607 102.782869) (xy 130.62061 102.782869) (xy 130.620612 102.782871)
-				(xy 130.774791 102.827664) (xy 130.774794 102.827664) (xy 130.774796 102.827665) (xy 130.810819 102.8305)
-				(xy 131.20918 102.830499) (xy 131.245204 102.827665) (xy 131.270905 102.820198) (xy 131.340773 102.820397)
-				(xy 131.399444 102.858338) (xy 131.428288 102.921976) (xy 131.4295 102.939274) (xy 131.4295 103.219169)
-				(xy 131.429501 103.219191) (xy 131.432098 103.252202) (xy 131.432335 103.255204) (xy 131.432335 103.255205)
-				(xy 131.449276 103.313513) (xy 131.4542 103.348109) (xy 131.4542 103.919453) (xy 131.454205 103.919554)
-				(xy 131.454205 103.970756) (xy 131.459823 104.027798) (xy 131.480815 104.240947) (xy 131.480818 104.240965)
-				(xy 131.53378 104.507234) (xy 131.533783 104.507245) (xy 131.612601 104.767077) (xy 131.70183 104.982494)
-				(xy 131.716504 105.017921) (xy 131.844493 105.257373) (xy 131.8445 105.257383) (xy 131.844507 105.257395)
-				(xy 131.995333 105.483125) (xy 131.995336 105.483128) (xy 132.167584 105.693015) (xy 132.205718 105.731149)
-				(xy 132.205727 105.731159) (xy 133.325963 106.851394) (xy 133.325969 106.851405) (xy 133.445128 106.970565)
-				(xy 133.526804 107.052241) (xy 133.683027 107.187608) (xy 133.878486 107.356974) (xy 134.251004 107.635838)
-				(xy 134.251028 107.635855) (xy 134.642466 107.887416) (xy 134.642477 107.887423) (xy 135.002954 108.084258)
-				(xy 135.0509 108.110438) (xy 135.050907 108.110442) (xy 135.474171 108.303739) (xy 135.474175 108.30374)
-				(xy 135.474185 108.303745) (xy 135.910185 108.466364) (xy 135.910192 108.466366) (xy 135.9102 108.466369)
-				(xy 136.221142 108.557669) (xy 136.3334 108.590631) (xy 136.356672 108.597464) (xy 136.356682 108.597467)
-				(xy 136.811373 108.696379) (xy 136.81138 108.69638) (xy 137.271984 108.762604) (xy 137.736138 108.795801)
-				(xy 137.968808 108.7958) (xy 141.396179 108.7958) (xy 141.474561 108.7958) (xy 141.480603 108.7958)
-				(xy 141.480766 108.795792) (xy 141.680193 108.795792) (xy 141.680206 108.795792) (xy 142.247222 108.761495)
-				(xy 142.811134 108.693025) (xy 143.369882 108.590632) (xy 143.921429 108.454689) (xy 144.463761 108.285692)
-				(xy 144.9949 108.084258) (xy 145.512908 107.851122) (xy 146.015894 107.587135) (xy 146.502023 107.29326)
-				(xy 146.969522 106.97057) (xy 147.359241 106.665245) (xy 147.416677 106.620247) (xy 147.416678 106.620246)
-				(xy 147.430306 106.608173) (xy 147.841878 106.243552) (xy 147.981445 106.103983) (xy 147.98146 106.103971)
-				(xy 147.98729 106.09814) (xy 147.987293 106.098139) (xy 149.727819 104.357611) (xy 149.789142 104.324127)
-				(xy 149.858834 104.329111) (xy 149.867767 104.335798) (xy 149.8 104.4) (xy 147.9 106.7) (xy 145.5 108.5)
-				(xy 137.5 110) (xy 133 108.5) (xy 130 104) (xy 122.5005 104) (xy 122.5005 102.929499) (xy 122.520185 102.86246)
-				(xy 122.572989 102.816705) (xy 122.6245 102.805499) (xy 124.797871 102.805499) (xy 124.797872 102.805499)
-				(xy 124.857483 102.799091) (xy 124.857485 102.79909) (xy 124.859347 102.79889) (xy 124.885863 102.7958)
-				(xy 127.480596 102.7958) (xy 127.515192 102.800724) (xy 127.539007 102.807643) (xy 127.57531 102.8105)
-				(xy 127.575318 102.8105) (xy 127.984682 102.8105) (xy 127.98469 102.8105) (xy 128.020993 102.807643)
-				(xy 128.020995 102.807642) (xy 128.020997 102.807642) (xy 128.061975 102.795736) (xy 128.176395 102.762494)
-				(xy 128.196879 102.750379) (xy 128.264601 102.733196) (xy 128.323119 102.750379) (xy 128.343605 102.762494)
-				(xy 128.343607 102.762494) (xy 128.343608 102.762495) (xy 128.499002 102.807642) (xy 128.499005 102.807642)
-				(xy 128.499007 102.807643) (xy 128.53531 102.8105) (xy 128.535318 102.8105) (xy 128.944682 102.8105)
-				(xy 128.94469 102.8105) (xy 128.980993 102.807643) (xy 128.980993 102.807642) (xy 128.987309 102.807146)
-				(xy 128.98731 102.807159) (xy 129.002314 102.8058) (xy 129.661889 102.8058) (xy 129.696484 102.810724)
-				(xy 129.754791 102.827664) (xy 129.754794 102.827664) (xy 129.754796 102.827665) (xy 129.790819 102.8305)
-				(xy 130.18918 102.830499) (xy 130.225204 102.827665) (xy 130.379393 102.782869) (xy 130.436882 102.748869)
-				(xy 130.504602 102.731688)
+				(xy 127.279062 102.700667) (xy 127.383605 102.762494) (xy 127.395969 102.766086) (xy 127.539002 102.807642)
+				(xy 127.539005 102.807642) (xy 127.539007 102.807643) (xy 127.57531 102.8105) (xy 127.575318 102.8105)
+				(xy 127.984682 102.8105) (xy 127.98469 102.8105) (xy 128.020993 102.807643) (xy 128.020995 102.807642)
+				(xy 128.020997 102.807642) (xy 128.061975 102.795736) (xy 128.176395 102.762494) (xy 128.196879 102.750379)
+				(xy 128.264601 102.733196) (xy 128.323119 102.750379) (xy 128.343605 102.762494) (xy 128.343607 102.762494)
+				(xy 128.343608 102.762495) (xy 128.499002 102.807642) (xy 128.499005 102.807642) (xy 128.499007 102.807643)
+				(xy 128.53531 102.8105) (xy 128.535318 102.8105) (xy 128.944682 102.8105) (xy 128.94469 102.8105)
+				(xy 128.980993 102.807643) (xy 128.980995 102.807642) (xy 128.980997 102.807642) (xy 129.021975 102.795736)
+				(xy 129.136395 102.762494) (xy 129.224028 102.710667) (xy 129.239929 102.706317) (xy 129.252214 102.698423)
+				(xy 129.287149 102.6934) (xy 129.4154 102.6934) (xy 129.478521 102.710668) (xy 129.566156 102.762495)
+				(xy 129.600607 102.782869) (xy 129.600614 102.782871) (xy 129.754791 102.827664) (xy 129.754794 102.827664)
+				(xy 129.754796 102.827665) (xy 129.790819 102.8305) (xy 130.18918 102.830499) (xy 130.225204 102.827665)
+				(xy 130.379393 102.782869) (xy 130.436882 102.748869) (xy 130.504602 102.731688) (xy 130.563117 102.748869)
+				(xy 130.620607 102.782869) (xy 130.62061 102.782869) (xy 130.620612 102.782871) (xy 130.774791 102.827664)
+				(xy 130.774794 102.827664) (xy 130.774796 102.827665) (xy 130.810819 102.8305) (xy 131.20918 102.830499)
+				(xy 131.245204 102.827665) (xy 131.270905 102.820198) (xy 131.340773 102.820397) (xy 131.399444 102.858338)
+				(xy 131.428288 102.921976) (xy 131.4295 102.939274) (xy 131.4295 103.219169) (xy 131.429501 103.219191)
+				(xy 131.432335 103.255205) (xy 131.477129 103.409388) (xy 131.477131 103.409393) (xy 131.549332 103.531478)
+				(xy 131.5666 103.594599) (xy 131.5666 103.908382) (xy 131.566605 103.908483) (xy 131.566605 103.983882)
+				(xy 131.599939 104.27974) (xy 131.599942 104.279754) (xy 131.666198 104.570043) (xy 131.764538 104.851085)
+				(xy 131.76454 104.851089) (xy 131.893723 105.119342) (xy 132.05214 105.371463) (xy 132.052149 105.371476)
+				(xy 132.237779 105.604251) (xy 132.237782 105.604254) (xy 132.29546 105.661932) (xy 132.295461 105.661934)
+				(xy 132.343053 105.709526) (xy 132.343052 105.709526) (xy 132.3975 105.763974) (xy 132.397502 105.763975)
+				(xy 133.405443 106.771917) (xy 133.405448 106.771926) (xy 133.441761 106.808239) (xy 133.603445 106.969923)
+				(xy 133.867614 107.198827) (xy 133.949058 107.269399) (xy 134.315149 107.543451) (xy 134.315154 107.543454)
+				(xy 134.699868 107.790695) (xy 134.89913 107.8995) (xy 135.101245 108.009863) (xy 135.101252 108.009867)
+				(xy 135.517212 108.199828) (xy 135.517216 108.199829) (xy 135.517226 108.199834) (xy 135.945703 108.359648)
+				(xy 136.357919 108.480685) (xy 136.384487 108.488486) (xy 136.384497 108.488489) (xy 136.831343 108.585694)
+				(xy 136.83135 108.585695) (xy 137.284006 108.650777) (xy 137.740152 108.6834) (xy 141.46969 108.6834)
+				(xy 141.469845 108.683392) (xy 141.67681 108.683393) (xy 142.237046 108.649506) (xy 142.794214 108.581854)
+				(xy 143.346281 108.480685) (xy 143.891232 108.346368) (xy 143.891236 108.346366) (xy 143.891243 108.346365)
+				(xy 144.046236 108.298067) (xy 144.42708 108.179392) (xy 144.951867 107.980367) (xy 145.463681 107.750019)
+				(xy 145.960652 107.489189) (xy 146.440968 107.198828) (xy 146.902877 106.879996) (xy 147.289673 106.576961)
+				(xy 147.344685 106.533862) (xy 147.344686 106.533861) (xy 147.344692 106.533856) (xy 147.764801 106.161672)
+				(xy 147.906704 106.019766) (xy 147.91564 106.010831) (xy 147.915642 106.010831) (xy 147.926921 105.999552)
+				(xy 147.926925 105.999549) (xy 147.963236 105.963236) (xy 147.963237 105.963237) (xy 148.017684 105.908789)
+				(xy 149.727819 104.198652) (xy 149.789142 104.165168) (xy 149.858834 104.170152) (xy 149.914767 104.212024)
+				(xy 149.936608 104.270581) (xy 149.8 104.4) (xy 147.9 106.7) (xy 145.5 108.5) (xy 137.5 110) (xy 133 108.5)
+				(xy 130 104) (xy 122.5005 104) (xy 122.5005 102.929499) (xy 122.520185 102.86246) (xy 122.572989 102.816705)
+				(xy 122.6245 102.805499) (xy 124.738781 102.805499) (xy 124.775588 102.808623) (xy 124.782995 102.808192)
+				(xy 124.801676 102.806758) (xy 124.814022 102.803762) (xy 124.857483 102.799091) (xy 124.895605 102.784871)
+				(xy 124.909675 102.780558) (xy 124.941501 102.772838) (xy 125.142726 102.692281) (xy 125.188811 102.6834)
+				(xy 127.215942 102.6834)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 137.418265 102.71508) (xy 137.47458 102.756436) (xy 137.499598 102.821673) (xy 137.5 102.831655)
-				(xy 137.5 103.4) (xy 138 103.4) (xy 135.3 104) (xy 134 104) (xy 135 105.5) (xy 137.5 106.5) (xy 144 106)
-				(xy 148.4 103.4) (xy 148.456899 103.338359) (xy 148.457444 103.342147) (xy 148.428419 103.405703)
-				(xy 148.422387 103.412181) (xy 146.929649 104.904919) (xy 146.918713 104.915854) (xy 146.915801 104.918672)
-				(xy 146.547332 105.263781) (xy 146.541232 105.269131) (xy 146.152539 105.588122) (xy 146.146101 105.593062)
-				(xy 145.737381 105.885946) (xy 145.730634 105.890454) (xy 145.303637 106.155978) (xy 145.29661 106.160035)
-				(xy 144.853164 106.397062) (xy 144.845886 106.400651) (xy 144.387873 106.608173) (xy 144.380377 106.611278)
-				(xy 143.909795 106.788392) (xy 143.902111 106.791001) (xy 143.420928 106.936966) (xy 143.41309 106.939066)
-				(xy 142.923405 107.053244) (xy 142.915447 107.054827) (xy 142.419336 107.136734) (xy 142.411291 107.137793)
-				(xy 141.910895 107.187077) (xy 141.902798 107.187608) (xy 141.565111 107.198662) (xy 141.397944 107.204134)
-				(xy 141.393908 107.2042) (xy 137.971231 107.2042) (xy 137.966363 107.204104) (xy 137.587431 107.189215)
-				(xy 137.577725 107.188452) (xy 137.203504 107.144161) (xy 137.193887 107.142637) (xy 136.824332 107.069128)
-				(xy 136.814864 107.066855) (xy 136.452206 106.964575) (xy 136.442947 106.961567) (xy 136.089425 106.831147)
-				(xy 136.080429 106.827421) (xy 135.738232 106.669666) (xy 135.729557 106.665245) (xy 135.400787 106.481124)
-				(xy 135.392486 106.476037) (xy 135.079185 106.266697) (xy 135.071307 106.260974) (xy 134.93812 106.155978)
-				(xy 134.775388 106.02769) (xy 134.767988 106.02137) (xy 134.626363 105.890454) (xy 134.489575 105.764008)
-				(xy 134.486071 105.760639) (xy 134.445931 105.7205) (xy 134.44593 105.720499) (xy 133.39246 104.667028)
-				(xy 133.38585 104.659878) (xy 133.275931 104.531177) (xy 133.264498 104.515441) (xy 133.178616 104.375295)
-				(xy 133.169786 104.357963) (xy 133.121322 104.24096) (xy 133.106888 104.206112) (xy 133.100878 104.187615)
-				(xy 133.06251 104.027798) (xy 133.059466 104.00858) (xy 133.046182 103.83979) (xy 133.0458 103.830061)
-				(xy 133.0458 103.348109) (xy 133.050724 103.313513) (xy 133.067665 103.255204) (xy 133.0705 103.219181)
-				(xy 133.070499 102.942177) (xy 133.090183 102.87514) (xy 133.142987 102.829385) (xy 133.212146 102.819441)
-				(xy 133.229083 102.8231) (xy 133.244796 102.827665) (xy 133.280819 102.8305) (xy 133.67918 102.830499)
-				(xy 133.715204 102.827665) (xy 133.869393 102.782869) (xy 133.926882 102.748869) (xy 133.994602 102.731688)
-				(xy 134.053117 102.748869) (xy 134.110607 102.782869) (xy 134.11061 102.782869) (xy 134.110612 102.782871)
-				(xy 134.264791 102.827664) (xy 134.264794 102.827664) (xy 134.264796 102.827665) (xy 134.300819 102.8305)
-				(xy 134.69918 102.830499) (xy 134.735204 102.827665) (xy 134.811875 102.805389) (xy 134.827936 102.800724)
-				(xy 134.862531 102.7958) (xy 135.490596 102.7958) (xy 135.525192 102.800724) (xy 135.549007 102.807643)
-				(xy 135.58531 102.8105) (xy 135.585318 102.8105) (xy 135.994682 102.8105) (xy 135.99469 102.8105)
-				(xy 136.030993 102.807643) (xy 136.030995 102.807642) (xy 136.030997 102.807642) (xy 136.071975 102.795736)
-				(xy 136.186395 102.762494) (xy 136.206879 102.750379) (xy 136.274601 102.733196) (xy 136.333119 102.750379)
-				(xy 136.353605 102.762494) (xy 136.353607 102.762494) (xy 136.353608 102.762495) (xy 136.509002 102.807642)
-				(xy 136.509005 102.807642) (xy 136.509007 102.807643) (xy 136.54531 102.8105) (xy 136.545318 102.8105)
-				(xy 136.954682 102.8105) (xy 136.95469 102.8105) (xy 136.990993 102.807643) (xy 137.146395 102.762494)
-				(xy 137.1464 102.76249) (xy 137.147934 102.761827) (xy 137.148402 102.761351) (xy 137.181351 102.748715)
-				(xy 137.348531 102.710736)
+				(xy 137.443039 102.672685) (xy 137.488794 102.725489) (xy 137.5 102.777) (xy 137.5 103.4) (xy 138 103.4)
+				(xy 135.3 104) (xy 134 104) (xy 135 105.5) (xy 137.5 106.5) (xy 144 106) (xy 148.4 103.4) (xy 148.56326 103.223134)
+				(xy 148.606459 103.272989) (xy 148.616403 103.342147) (xy 148.587378 103.405703) (xy 148.581346 103.412181)
+				(xy 147.051211 104.942316) (xy 147.011032 104.982494) (xy 146.998195 104.995331) (xy 146.99528 104.998151)
+				(xy 146.621442 105.348288) (xy 146.615342 105.353638) (xy 146.220964 105.677295) (xy 146.214526 105.682235)
+				(xy 145.799827 105.979404) (xy 145.79308 105.983912) (xy 145.359837 106.25332) (xy 145.35281 106.257377)
+				(xy 144.902877 106.49787) (xy 144.8956 106.501459) (xy 144.430888 106.712017) (xy 144.423391 106.715122)
+				(xy 143.945925 106.894827) (xy 143.938241 106.897436) (xy 143.450019 107.045536) (xy 143.442181 107.047636)
+				(xy 142.945333 107.163484) (xy 142.937375 107.165067) (xy 142.434007 107.248173) (xy 142.425962 107.249232)
+				(xy 141.918246 107.299236) (xy 141.910149 107.299767) (xy 141.555949 107.311362) (xy 141.397945 107.316534)
+				(xy 141.393907 107.3166) (xy 137.971231 107.3166) (xy 137.966363 107.316504) (xy 137.578611 107.301269)
+				(xy 137.568905 107.300506) (xy 137.185923 107.255178) (xy 137.176306 107.253654) (xy 136.798092 107.178423)
+				(xy 136.788624 107.17615) (xy 136.417476 107.071475) (xy 136.408216 107.068467) (xy 136.046408 106.934989)
+				(xy 136.037413 106.931263) (xy 135.687203 106.769815) (xy 135.678528 106.765394) (xy 135.342057 106.576961)
+				(xy 135.333755 106.571874) (xy 135.013117 106.357631) (xy 135.00524 106.351908) (xy 134.702394 106.113163)
+				(xy 134.694991 106.10684) (xy 134.410072 105.843463) (xy 134.406562 105.840088) (xy 133.345481 104.779008)
+				(xy 133.34548 104.779007) (xy 133.312968 104.746495) (xy 133.306372 104.739358) (xy 133.184998 104.597246)
+				(xy 133.173561 104.581504) (xy 133.166537 104.570041) (xy 133.078467 104.426323) (xy 133.069637 104.408992)
+				(xy 132.999989 104.240845) (xy 132.99398 104.222352) (xy 132.951492 104.045376) (xy 132.948449 104.026163)
+				(xy 132.944675 103.978211) (xy 132.933781 103.839787) (xy 132.9334 103.830064) (xy 132.9334 103.594599)
+				(xy 132.950668 103.531478) (xy 132.979044 103.483497) (xy 133.022869 103.409393) (xy 133.067665 103.255204)
+				(xy 133.0705 103.219181) (xy 133.070499 102.942177) (xy 133.090183 102.87514) (xy 133.142987 102.829385)
+				(xy 133.212146 102.819441) (xy 133.229083 102.8231) (xy 133.244796 102.827665) (xy 133.280819 102.8305)
+				(xy 133.67918 102.830499) (xy 133.715204 102.827665) (xy 133.869393 102.782869) (xy 133.926882 102.748869)
+				(xy 133.994602 102.731688) (xy 134.053117 102.748869) (xy 134.110607 102.782869) (xy 134.11061 102.782869)
+				(xy 134.110612 102.782871) (xy 134.264791 102.827664) (xy 134.264794 102.827664) (xy 134.264796 102.827665)
+				(xy 134.300819 102.8305) (xy 134.69918 102.830499) (xy 134.735204 102.827665) (xy 134.889393 102.782869)
+				(xy 135.027598 102.701135) (xy 135.027597 102.701135) (xy 135.028388 102.700668) (xy 135.044289 102.696317)
+				(xy 135.056574 102.688423) (xy 135.091509 102.6834) (xy 135.225942 102.6834) (xy 135.289062 102.700667)
+				(xy 135.393605 102.762494) (xy 135.405969 102.766086) (xy 135.549002 102.807642) (xy 135.549005 102.807642)
+				(xy 135.549007 102.807643) (xy 135.58531 102.8105) (xy 135.585318 102.8105) (xy 135.994682 102.8105)
+				(xy 135.99469 102.8105) (xy 136.030993 102.807643) (xy 136.030995 102.807642) (xy 136.030997 102.807642)
+				(xy 136.071975 102.795736) (xy 136.186395 102.762494) (xy 136.206879 102.750379) (xy 136.274601 102.733196)
+				(xy 136.333119 102.750379) (xy 136.353605 102.762494) (xy 136.353607 102.762494) (xy 136.353608 102.762495)
+				(xy 136.509002 102.807642) (xy 136.509005 102.807642) (xy 136.509007 102.807643) (xy 136.54531 102.8105)
+				(xy 136.545318 102.8105) (xy 136.954682 102.8105) (xy 136.95469 102.8105) (xy 136.990993 102.807643)
+				(xy 136.990995 102.807642) (xy 136.990997 102.807642) (xy 137.031975 102.795736) (xy 137.146395 102.762494)
+				(xy 137.285687 102.680117) (xy 137.285692 102.680111) (xy 137.287101 102.67902) (xy 137.288413 102.678504)
+				(xy 137.292402 102.676146) (xy 137.292782 102.676789) (xy 137.308671 102.670551) (xy 137.328166 102.658023)
+				(xy 137.347756 102.655206) (xy 137.352138 102.653486) (xy 137.363101 102.653) (xy 137.376 102.653)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 138 100.1) (xy 137.5 100.1) (xy 137.5 101.154726) (xy 137.494143 101.17467) (xy 137.493128 101.195433)
-				(xy 137.484498 101.207519) (xy 137.480315 101.221765) (xy 137.464608 101.235374) (xy 137.452527 101.252295)
-				(xy 137.438731 101.257797) (xy 137.427511 101.26752) (xy 137.406939 101.270477) (xy 137.387629 101.27818)
-				(xy 137.362071 101.276929) (xy 137.358353 101.277464) (xy 137.352377 101.276455) (xy 137.141323 101.235497)
-				(xy 137.130351 101.232844) (xy 136.990997 101.192357) (xy 136.990991 101.192356) (xy 136.954697 101.1895)
-				(xy 136.95469 101.1895) (xy 136.54531 101.1895) (xy 136.545302 101.1895) (xy 136.509008 101.192356)
-				(xy 136.509002 101.192357) (xy 136.353608 101.237504) (xy 136.353602 101.237506) (xy 136.33312 101.24962)
-				(xy 136.265396 101.266801) (xy 136.20688 101.24962) (xy 136.186397 101.237506) (xy 136.186391 101.237504)
-				(xy 136.030997 101.192357) (xy 136.030991 101.192356) (xy 135.994697 101.1895) (xy 135.99469 101.1895)
-				(xy 135.58531 101.1895) (xy 135.585302 101.1895) (xy 135.549008 101.192356) (xy 135.549005 101.192357)
-				(xy 135.525192 101.199276) (xy 135.490596 101.2042) (xy 134.793693 101.2042) (xy 134.759101 101.199277)
-				(xy 134.73521 101.192336) (xy 134.735197 101.192334) (xy 134.699181 101.1895) (xy 134.30083 101.1895)
+				(xy 138 100.1) (xy 137.5 100.1) (xy 137.5 101.198) (xy 137.497449 101.206685) (xy 137.498738 101.215647)
+				(xy 137.487759 101.239687) (xy 137.480315 101.265039) (xy 137.473474 101.270966) (xy 137.469713 101.279203)
+				(xy 137.447478 101.293492) (xy 137.427511 101.310794) (xy 137.416996 101.313081) (xy 137.410935 101.316977)
+				(xy 137.376 101.322) (xy 137.323189 101.322) (xy 137.260068 101.304732) (xy 137.232298 101.288309)
+				(xy 137.146395 101.237506) (xy 137.146394 101.237505) (xy 137.146393 101.237505) (xy 137.14639 101.237504)
+				(xy 136.990997 101.192357) (xy 136.990991 101.192356) (xy 136.954697 101.1895) (xy 136.95469 101.1895)
+				(xy 136.54531 101.1895) (xy 136.545302 101.1895) (xy 136.509008 101.192356) (xy 136.509002 101.192357)
+				(xy 136.353608 101.237504) (xy 136.353602 101.237506) (xy 136.33312 101.24962) (xy 136.265396 101.266801)
+				(xy 136.20688 101.24962) (xy 136.186397 101.237506) (xy 136.186391 101.237504) (xy 136.030997 101.192357)
+				(xy 136.030991 101.192356) (xy 135.994697 101.1895) (xy 135.99469 101.1895) (xy 135.58531 101.1895)
+				(xy 135.585302 101.1895) (xy 135.549008 101.192356) (xy 135.549002 101.192357) (xy 135.393609 101.237504)
+				(xy 135.393606 101.237505) (xy 135.289063 101.299332) (xy 135.273161 101.303682) (xy 135.260877 101.311577)
+				(xy 135.225942 101.3166) (xy 135.05769 101.3166) (xy 134.994569 101.299332) (xy 134.97363 101.286949)
+				(xy 134.889393 101.237131) (xy 134.889392 101.23713) (xy 134.889391 101.23713) (xy 134.889388 101.237129)
+				(xy 134.735208 101.192335) (xy 134.735202 101.192334) (xy 134.699181 101.1895) (xy 134.30083 101.1895)
 				(xy 134.300808 101.189501) (xy 134.264794 101.192335) (xy 134.110611 101.237129) (xy 134.110604 101.237132)
 				(xy 134.053119 101.271128) (xy 133.985395 101.288309) (xy 133.926881 101.271128) (xy 133.869395 101.237132)
 				(xy 133.869388 101.237129) (xy 133.715208 101.192335) (xy 133.715202 101.192334) (xy 133.679181 101.1895)
-				(xy 133.28083 101.1895) (xy 133.280808 101.189501) (xy 133.244794 101.192335) (xy 133.186484 101.209276)
-				(xy 133.151889 101.2142) (xy 132.39087 101.2142) (xy 132.385374 101.214078) (xy 132.375939 101.213659)
-				(xy 132.32838 101.204199) (xy 132.17162 101.204199) (xy 132.171615 101.2042) (xy 131.303693 101.2042)
-				(xy 131.269101 101.199277) (xy 131.24521 101.192336) (xy 131.245197 101.192334) (xy 131.209181 101.1895)
+				(xy 133.28083 101.1895) (xy 133.280808 101.189501) (xy 133.244794 101.192335) (xy 133.090611 101.237129)
+				(xy 133.090605 101.237131) (xy 132.968521 101.309332) (xy 132.952619 101.313682) (xy 132.940335 101.321577)
+				(xy 132.9054 101.3266) (xy 132.806963 101.3266) (xy 132.743842 101.309332) (xy 132.742362 101.308457)
+				(xy 132.689393 101.277131) (xy 132.689388 101.277129) (xy 132.535208 101.232335) (xy 132.535202 101.232334)
+				(xy 132.499181 101.2295) (xy 132.00083 101.2295) (xy 132.000808 101.229501) (xy 131.964794 101.232335)
+				(xy 131.810611 101.277129) (xy 131.810605 101.277131) (xy 131.773067 101.299332) (xy 131.757165 101.303682)
+				(xy 131.744881 101.311577) (xy 131.709946 101.3166) (xy 131.56769 101.3166) (xy 131.504569 101.299332)
+				(xy 131.48363 101.286949) (xy 131.399393 101.237131) (xy 131.399392 101.23713) (xy 131.399391 101.23713)
+				(xy 131.399388 101.237129) (xy 131.245208 101.192335) (xy 131.245202 101.192334) (xy 131.209181 101.1895)
 				(xy 130.81083 101.1895) (xy 130.810808 101.189501) (xy 130.774794 101.192335) (xy 130.620611 101.237129)
 				(xy 130.620604 101.237132) (xy 130.563119 101.271128) (xy 130.495395 101.288309) (xy 130.436881 101.271128)
 				(xy 130.379395 101.237132) (xy 130.379388 101.237129) (xy 130.225208 101.192335) (xy 130.225202 101.192334)
 				(xy 130.189181 101.1895) (xy 129.79083 101.1895) (xy 129.790808 101.189501) (xy 129.754794 101.192335)
-				(xy 129.696484 101.209276) (xy 129.661889 101.2142) (xy 129.073823 101.2142) (xy 129.039228 101.209276)
-				(xy 129.010429 101.200909) (xy 128.980994 101.192357) (xy 128.980991 101.192356) (xy 128.944697 101.1895)
-				(xy 128.94469 101.1895) (xy 128.53531 101.1895) (xy 128.535302 101.1895) (xy 128.499008 101.192356)
-				(xy 128.499002 101.192357) (xy 128.343608 101.237504) (xy 128.343602 101.237506) (xy 128.32312 101.24962)
-				(xy 128.255396 101.266801) (xy 128.19688 101.24962) (xy 128.176397 101.237506) (xy 128.176391 101.237504)
-				(xy 128.020997 101.192357) (xy 128.020991 101.192356) (xy 127.984697 101.1895) (xy 127.98469 101.1895)
-				(xy 127.57531 101.1895) (xy 127.575302 101.1895) (xy 127.539008 101.192356) (xy 127.539005 101.192357)
-				(xy 127.515192 101.199276) (xy 127.480596 101.2042) (xy 124.885861 101.2042) (xy 124.859267 101.2011)
-				(xy 124.797883 101.194501) (xy 124.797881 101.1945) (xy 124.797873 101.1945) (xy 124.797865 101.1945)
-				(xy 122.6245 101.1945) (xy 122.557461 101.174815) (xy 122.511706 101.122011) (xy 122.5005 101.0705)
-				(xy 122.5005 100) (xy 138 100)
+				(xy 129.600611 101.237129) (xy 129.600605 101.237131) (xy 129.478521 101.309332) (xy 129.462619 101.313682)
+				(xy 129.450335 101.321577) (xy 129.4154 101.3266) (xy 129.320967 101.3266) (xy 129.257846 101.309332)
+				(xy 129.136395 101.237506) (xy 129.136394 101.237505) (xy 129.136393 101.237505) (xy 129.13639 101.237504)
+				(xy 128.980997 101.192357) (xy 128.980991 101.192356) (xy 128.944697 101.1895) (xy 128.94469 101.1895)
+				(xy 128.53531 101.1895) (xy 128.535302 101.1895) (xy 128.499008 101.192356) (xy 128.499002 101.192357)
+				(xy 128.343608 101.237504) (xy 128.343602 101.237506) (xy 128.32312 101.24962) (xy 128.255396 101.266801)
+				(xy 128.19688 101.24962) (xy 128.176397 101.237506) (xy 128.176391 101.237504) (xy 128.020997 101.192357)
+				(xy 128.020991 101.192356) (xy 127.984697 101.1895) (xy 127.98469 101.1895) (xy 127.57531 101.1895)
+				(xy 127.575302 101.1895) (xy 127.539008 101.192356) (xy 127.539002 101.192357) (xy 127.383609 101.237504)
+				(xy 127.383606 101.237505) (xy 127.279063 101.299332) (xy 127.215942 101.3166) (xy 125.188814 101.3166)
+				(xy 125.142729 101.307718) (xy 125.132647 101.303682) (xy 125.094247 101.288309) (xy 124.941489 101.227155)
+				(xy 124.923935 101.220504) (xy 124.923925 101.220501) (xy 124.90281 101.216202) (xy 124.90281 101.216203)
+				(xy 124.897475 101.215117) (xy 124.8933 101.214267) (xy 124.857483 101.200909) (xy 124.797873 101.1945)
+				(xy 124.796194 101.1945) (xy 124.788624 101.192959) (xy 124.788616 101.192958) (xy 124.782941 101.191803)
+				(xy 124.782937 101.191802) (xy 124.782929 101.191801) (xy 124.775566 101.191373) (xy 124.756879 101.190633)
+				(xy 124.734531 101.193367) (xy 124.73278 101.193582) (xy 124.717724 101.1945) (xy 122.6245 101.1945)
+				(xy 122.557461 101.174815) (xy 122.511706 101.122011) (xy 122.5005 101.0705) (xy 122.5005 100) (xy 138 100)
+			)
+		)
+	)
+	(zone
+		(net 16)
+		(net_name "/rf_out")
+		(layer "F.Cu")
+		(uuid "64da241d-ca9f-47c8-b20d-d9ea019cb181")
+		(name "$teardrop_padvia$")
+		(hatch full 0.1)
+		(priority 30000)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 125.055 102.1829) (xy 125.055 101.8171) (xy 124.75 101.695) (xy 123.624 102) (xy 124.75 102.305)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 124.753629 101.696452) (xy 125.047649 101.814157) (xy 125.054055 101.820412) (xy 125.055 101.825018)
+				(xy 125.055 102.174981) (xy 125.051573 102.183254) (xy 125.047648 102.185843) (xy 124.753631 102.303546)
+				(xy 124.746224 102.303977) (xy 124.127966 102.136509) (xy 123.66569 102.011292) (xy 123.658602 102.005822)
+				(xy 123.657457 101.996941) (xy 123.662928 101.989852) (xy 123.665689 101.988707) (xy 124.746226 101.696022)
 			)
 		)
 	)
@@ -31408,55 +31243,56 @@
 				(xy 159.58946 110.335511) (xy 161.168152 108.756819) (xy 161.229475 108.723334) (xy 161.255833 108.7205)
 				(xy 161.474317 108.7205) (xy 161.490601 108.718356) (xy 161.523173 108.714068) (xy 161.630404 108.664065)
 				(xy 161.714065 108.580404) (xy 161.764068 108.473173) (xy 161.7705 108.424316) (xy 161.7705 108.075684)
-				(xy 161.764068 108.026827) (xy 161.714065 107.919596) (xy 161.630404 107.835935) (xy 161.622733 107.828264)
-				(xy 161.625561 107.825435) (xy 161.594843 107.787023) (xy 161.587635 107.717526) (xy 161.619143 107.655165)
-				(xy 161.622028 107.652191) (xy 161.629978 107.644263) (xy 161.630404 107.644065) (xy 161.707778 107.566691)
-				(xy 161.738585 107.549927) (xy 161.768973 107.533334) (xy 161.769104 107.533319) (xy 161.76915 107.533295)
-				(xy 161.76926 107.533303) (xy 161.795331 107.5305) (xy 161.944669 107.5305) (xy 162.011708 107.550185)
-				(xy 162.03235 107.566819) (xy 162.035935 107.570404) (xy 162.119596 107.654065) (xy 162.226827 107.704068)
-				(xy 162.275683 107.7105) (xy 162.275684 107.7105) (xy 162.724317 107.7105) (xy 162.740601 107.708356)
-				(xy 162.773173 107.704068) (xy 162.880404 107.654065) (xy 162.964065 107.570404) (xy 163.014068 107.463173)
-				(xy 163.0205 107.414316) (xy 163.0205 107.195833) (xy 163.040185 107.128794) (xy 163.056819 107.108152)
-				(xy 163.988794 106.176177) (xy 164.93146 105.233511) (xy 164.948203 105.204511) (xy 164.971021 105.164989)
-				(xy 164.9915 105.088562) (xy 164.9915 103.483678) (xy 164.971021 103.407251) (xy 164.966835 103.4)
-				(xy 164.931464 103.338735) (xy 164.931458 103.338727) (xy 164.201272 102.608541) (xy 164.19482 102.60359)
-				(xy 164.196898 102.60088) (xy 164.159574 102.561721) (xy 164.146364 102.493112) (xy 164.172344 102.428252)
-				(xy 164.200916 102.401816) (xy 164.209655 102.395977) (xy 164.355977 102.249655) (xy 164.470941 102.077598)
-				(xy 164.55013 101.88642) (xy 164.5905 101.683465) (xy 164.5905 101.476535) (xy 164.55013 101.27358)
-				(xy 164.470941 101.082402) (xy 164.355977 100.910345) (xy 164.355975 100.910342) (xy 164.209657 100.764024)
-				(xy 164.059058 100.663398) (xy 164.037598 100.649059) (xy 164.037192 100.648891) (xy 163.84642 100.56987)
-				(xy 163.846412 100.569868) (xy 163.643469 100.5295) (xy 163.643465 100.5295) (xy 163.436535 100.5295)
-				(xy 163.43653 100.5295) (xy 163.233587 100.569868) (xy 163.233579 100.56987) (xy 163.042403 100.649058)
-				(xy 162.870342 100.764024) (xy 162.724024 100.910342) (xy 162.609058 101.082403) (xy 162.52987 101.273579)
-				(xy 162.529868 101.273587) (xy 162.4895 101.47653) (xy 162.4895 101.683469) (xy 162.529868 101.886412)
-				(xy 162.529871 101.886424) (xy 162.579803 102.006971) (xy 162.587272 102.07644) (xy 162.555997 102.138919)
-				(xy 162.552924 102.142104) (xy 162.300846 102.394182) (xy 162.239526 102.427666) (xy 162.213167 102.4305)
-				(xy 161.927128 102.4305) (xy 161.860089 102.410815) (xy 161.814334 102.358011) (xy 161.80439 102.288853)
-				(xy 161.824026 102.23761) (xy 161.93094 102.0776) (xy 161.93094 102.077599) (xy 161.930941 102.077598)
-				(xy 162.01013 101.88642) (xy 162.0505 101.683465) (xy 162.0505 101.476535) (xy 162.01013 101.27358)
-				(xy 161.930941 101.082402) (xy 161.815977 100.910345) (xy 161.815975 100.910342) (xy 161.812112 100.905635)
-				(xy 161.813581 100.904429) (xy 161.784329 100.850858) (xy 161.789313 100.781166) (xy 161.831185 100.725233)
-				(xy 161.896649 100.700816) (xy 161.905495 100.7005) (xy 162.21956 100.7005) (xy 162.219562 100.7005)
-				(xy 162.295989 100.680021) (xy 162.364511 100.64046) (xy 162.42046 100.584511) (xy 162.977896 100.027073)
-				(xy 163.039217 99.99359) (xy 163.108908 99.998574) (xy 163.113007 100.000186) (xy 163.23358 100.05013)
-				(xy 163.413585 100.085935) (xy 163.43653 100.090499) (xy 163.436534 100.0905) (xy 163.436535 100.0905)
-				(xy 163.643466 100.0905) (xy 163.643467 100.090499) (xy 163.84642 100.05013) (xy 164.037598 99.970941)
-				(xy 164.209655 99.855977) (xy 164.355977 99.709655) (xy 164.470941 99.537598) (xy 164.55013 99.34642)
-				(xy 164.5905 99.143465) (xy 164.5905 98.936535) (xy 164.55013 98.73358) (xy 164.470941 98.542402)
-				(xy 164.355977 98.370345) (xy 164.355975 98.370342) (xy 164.209657 98.224024) (xy 164.123626 98.166541)
-				(xy 164.037598 98.109059) (xy 164.029679 98.105779) (xy 163.84642 98.02987) (xy 163.846412 98.029868)
-				(xy 163.643469 97.9895) (xy 163.643465 97.9895) (xy 163.436535 97.9895) (xy 163.43653 97.9895) (xy 163.233587 98.029868)
-				(xy 163.233579 98.02987) (xy 163.042403 98.109058) (xy 162.870342 98.224024) (xy 162.724024 98.370342)
-				(xy 162.609058 98.542403) (xy 162.52987 98.733579) (xy 162.529868 98.733587) (xy 162.4895 98.93653)
-				(xy 162.4895 99.143469) (xy 162.529868 99.346412) (xy 162.529871 99.346424) (xy 162.579803 99.466971)
-				(xy 162.587272 99.53644) (xy 162.555997 99.598919) (xy 162.552923 99.602104) (xy 162.091848 100.063181)
-				(xy 162.030525 100.096666) (xy 162.004167 100.0995) (xy 161.71397 100.0995) (xy 161.646931 100.079815)
-				(xy 161.601176 100.027011) (xy 161.591232 99.957853) (xy 161.620257 99.894297) (xy 161.645078 99.872398)
-				(xy 161.669655 99.855977) (xy 161.815977 99.709655) (xy 161.930941 99.537598) (xy 162.01013 99.34642)
-				(xy 162.0505 99.143465) (xy 162.0505 98.936535) (xy 162.01013 98.73358) (xy 161.930941 98.542402)
-				(xy 161.815977 98.370345) (xy 161.815975 98.370342) (xy 161.669657 98.224024) (xy 161.583626 98.166541)
-				(xy 161.497598 98.109059) (xy 161.489679 98.105779) (xy 161.30642 98.02987) (xy 161.306412 98.029868)
-				(xy 161.103469 97.9895) (xy 161.103465 97.9895) (xy 160.896535 97.9895) (xy 160.89653 97.9895) (xy 160.693587 98.029868)
+				(xy 161.770385 108.074814) (xy 161.766943 108.048662) (xy 161.764068 108.026827) (xy 161.714065 107.919596)
+				(xy 161.630404 107.835935) (xy 161.622733 107.828264) (xy 161.625561 107.825435) (xy 161.594843 107.787023)
+				(xy 161.587635 107.717526) (xy 161.619143 107.655165) (xy 161.622028 107.652191) (xy 161.629978 107.644263)
+				(xy 161.630404 107.644065) (xy 161.707778 107.566691) (xy 161.738585 107.549927) (xy 161.768973 107.533334)
+				(xy 161.769104 107.533319) (xy 161.76915 107.533295) (xy 161.76926 107.533303) (xy 161.795331 107.5305)
+				(xy 161.944669 107.5305) (xy 162.011708 107.550185) (xy 162.03235 107.566819) (xy 162.035935 107.570404)
+				(xy 162.119596 107.654065) (xy 162.226827 107.704068) (xy 162.275683 107.7105) (xy 162.275684 107.7105)
+				(xy 162.724317 107.7105) (xy 162.740601 107.708356) (xy 162.773173 107.704068) (xy 162.880404 107.654065)
+				(xy 162.964065 107.570404) (xy 163.014068 107.463173) (xy 163.0205 107.414316) (xy 163.0205 107.195833)
+				(xy 163.040185 107.128794) (xy 163.056819 107.108152) (xy 163.988794 106.176177) (xy 164.93146 105.233511)
+				(xy 164.945672 105.208895) (xy 164.971021 105.164989) (xy 164.9915 105.088562) (xy 164.9915 103.483678)
+				(xy 164.971021 103.407251) (xy 164.966835 103.4) (xy 164.931464 103.338735) (xy 164.931458 103.338727)
+				(xy 164.201272 102.608541) (xy 164.19482 102.60359) (xy 164.196898 102.60088) (xy 164.159574 102.561721)
+				(xy 164.146364 102.493112) (xy 164.172344 102.428252) (xy 164.200916 102.401816) (xy 164.209655 102.395977)
+				(xy 164.355977 102.249655) (xy 164.470941 102.077598) (xy 164.55013 101.88642) (xy 164.5905 101.683465)
+				(xy 164.5905 101.476535) (xy 164.55013 101.27358) (xy 164.470941 101.082402) (xy 164.355977 100.910345)
+				(xy 164.355975 100.910342) (xy 164.209657 100.764024) (xy 164.059058 100.663398) (xy 164.037598 100.649059)
+				(xy 164.037192 100.648891) (xy 163.84642 100.56987) (xy 163.846412 100.569868) (xy 163.643469 100.5295)
+				(xy 163.643465 100.5295) (xy 163.436535 100.5295) (xy 163.43653 100.5295) (xy 163.233587 100.569868)
+				(xy 163.233579 100.56987) (xy 163.042403 100.649058) (xy 162.870342 100.764024) (xy 162.724024 100.910342)
+				(xy 162.609058 101.082403) (xy 162.52987 101.273579) (xy 162.529868 101.273587) (xy 162.4895 101.47653)
+				(xy 162.4895 101.683469) (xy 162.529868 101.886412) (xy 162.529871 101.886424) (xy 162.579803 102.006971)
+				(xy 162.587272 102.07644) (xy 162.555997 102.138919) (xy 162.552924 102.142104) (xy 162.300846 102.394182)
+				(xy 162.239526 102.427666) (xy 162.213167 102.4305) (xy 161.927128 102.4305) (xy 161.860089 102.410815)
+				(xy 161.814334 102.358011) (xy 161.80439 102.288853) (xy 161.824026 102.23761) (xy 161.93094 102.0776)
+				(xy 161.93094 102.077599) (xy 161.930941 102.077598) (xy 162.01013 101.88642) (xy 162.0505 101.683465)
+				(xy 162.0505 101.476535) (xy 162.01013 101.27358) (xy 161.930941 101.082402) (xy 161.815977 100.910345)
+				(xy 161.815975 100.910342) (xy 161.812112 100.905635) (xy 161.813581 100.904429) (xy 161.784329 100.850858)
+				(xy 161.789313 100.781166) (xy 161.831185 100.725233) (xy 161.896649 100.700816) (xy 161.905495 100.7005)
+				(xy 162.21956 100.7005) (xy 162.219562 100.7005) (xy 162.295989 100.680021) (xy 162.364511 100.64046)
+				(xy 162.42046 100.584511) (xy 162.977896 100.027073) (xy 163.039217 99.99359) (xy 163.108908 99.998574)
+				(xy 163.113007 100.000186) (xy 163.23358 100.05013) (xy 163.413585 100.085935) (xy 163.43653 100.090499)
+				(xy 163.436534 100.0905) (xy 163.436535 100.0905) (xy 163.643466 100.0905) (xy 163.643467 100.090499)
+				(xy 163.84642 100.05013) (xy 164.037598 99.970941) (xy 164.209655 99.855977) (xy 164.355977 99.709655)
+				(xy 164.470941 99.537598) (xy 164.55013 99.34642) (xy 164.5905 99.143465) (xy 164.5905 98.936535)
+				(xy 164.55013 98.73358) (xy 164.470941 98.542402) (xy 164.355977 98.370345) (xy 164.355975 98.370342)
+				(xy 164.209657 98.224024) (xy 164.123626 98.166541) (xy 164.037598 98.109059) (xy 164.029679 98.105779)
+				(xy 163.84642 98.02987) (xy 163.846412 98.029868) (xy 163.643469 97.9895) (xy 163.643465 97.9895)
+				(xy 163.436535 97.9895) (xy 163.43653 97.9895) (xy 163.233587 98.029868) (xy 163.233579 98.02987)
+				(xy 163.042403 98.109058) (xy 162.870342 98.224024) (xy 162.724024 98.370342) (xy 162.609058 98.542403)
+				(xy 162.52987 98.733579) (xy 162.529868 98.733587) (xy 162.4895 98.93653) (xy 162.4895 99.143469)
+				(xy 162.529868 99.346412) (xy 162.529871 99.346424) (xy 162.579803 99.466971) (xy 162.587272 99.53644)
+				(xy 162.555997 99.598919) (xy 162.552923 99.602104) (xy 162.091848 100.063181) (xy 162.030525 100.096666)
+				(xy 162.004167 100.0995) (xy 161.71397 100.0995) (xy 161.646931 100.079815) (xy 161.601176 100.027011)
+				(xy 161.591232 99.957853) (xy 161.620257 99.894297) (xy 161.645078 99.872398) (xy 161.669655 99.855977)
+				(xy 161.815977 99.709655) (xy 161.930941 99.537598) (xy 162.01013 99.34642) (xy 162.0505 99.143465)
+				(xy 162.0505 98.936535) (xy 162.01013 98.73358) (xy 161.930941 98.542402) (xy 161.815977 98.370345)
+				(xy 161.815975 98.370342) (xy 161.669657 98.224024) (xy 161.583626 98.166541) (xy 161.497598 98.109059)
+				(xy 161.489679 98.105779) (xy 161.30642 98.02987) (xy 161.306412 98.029868) (xy 161.103469 97.9895)
+				(xy 161.103465 97.9895) (xy 160.896535 97.9895) (xy 160.89653 97.9895) (xy 160.693587 98.029868)
 				(xy 160.693579 98.02987) (xy 160.502403 98.109058) (xy 160.330342 98.224024) (xy 160.184027 98.370339)
 				(xy 160.184024 98.370343) (xy 160.167956 98.394391) (xy 160.114343 98.439196) (xy 160.064854 98.4495)
 				(xy 158.560321 98.4495) (xy 158.493282 98.429815) (xy 158.447939 98.377904) (xy 158.444065 98.369596)
@@ -31536,7 +31372,7 @@
 				(xy 164.389639 110.034869) (xy 164.389641 110.03487) (xy 164.5 110.0555) (xy 164.500002 110.0555)
 				(xy 165.749998 110.0555) (xy 165.75 110.0555) (xy 165.778188 110.054197) (xy 165.886173 110.023472)
 				(xy 165.975767 109.955814) (xy 166.03487 109.860359) (xy 166.0555 109.75) (xy 166.0555 108.5) (xy 166.054197 108.471812)
-				(xy 166.023472 108.363827) (xy 165.973142 108.297179) (xy 165.955813 108.274231) (xy 165.947323 108.266492)
+				(xy 166.023472 108.363827) (xy 165.97369 108.297905) (xy 165.955813 108.274231) (xy 165.947323 108.266492)
 				(xy 165.950167 108.263372) (xy 165.918361 108.227869) (xy 165.907275 108.158884) (xy 165.935246 108.094857)
 				(xy 165.993391 108.056117) (xy 166.030288 108.0505) (xy 166.319679 108.0505) (xy 166.386718 108.070185)
 				(xy 166.412963 108.092804) (xy 166.424595 108.106086) (xy 166.435935 108.130404) (xy 166.51609 108.210559)
@@ -31892,7 +31728,7 @@
 				(xy 160.611562 108.003445) (xy 160.593139 107.997876) (xy 160.582495 107.985392) (xy 160.568559 107.976738)
 				(xy 160.560293 107.959355) (xy 160.547806 107.94471) (xy 160.54174 107.928031) (xy 160.523473 107.86383)
 				(xy 160.523472 107.863829) (xy 160.523472 107.863827) (xy 160.455814 107.774233) (xy 160.455813 107.774232)
-				(xy 160.36036 107.71513) (xy 160.360361 107.71513) (xy 160.298931 107.703647) (xy 160.25 107.6945)
+				(xy 160.36036 107.71513) (xy 160.360361 107.71513) (xy 160.295898 107.70308) (xy 160.25 107.6945)
 				(xy 157 107.6945) (xy 156.99713 107.694632) (xy 156.971816 107.695802) (xy 156.971807 107.695804)
 				(xy 156.86383 107.726526) (xy 156.86382 107.726531) (xy 156.857202 107.731529) (xy 156.847253 107.736105)
 				(xy 156.84204 107.741331) (xy 156.8127 107.751997) (xy 156.808987 107.753706) (xy 156.807787 107.753968)
@@ -31916,193 +31752,193 @@
 				(xy 155.571769 106.938867) (xy 155.57177 106.938868) (xy 155.630247 106.950499) (xy 155.63025 106.9505)
 				(xy 155.630252 106.9505) (xy 156.46975 106.9505) (xy 156.469751 106.950499) (xy 156.484568 106.947552)
 				(xy 156.528229 106.938868) (xy 156.528229 106.938867) (xy 156.528231 106.938867) (xy 156.594552 106.894552)
-				(xy 156.638867 106.828231) (xy 156.638867 106.828229) (xy 156.638868 106.828229) (xy 156.650499 106.769752)
-				(xy 156.6505 106.76975) (xy 156.6505 106.130249) (xy 156.650499 106.130247) (xy 156.638868 106.07177)
-				(xy 156.638867 106.071769) (xy 156.594552 106.005447) (xy 156.52823 105.961132) (xy 156.528229 105.961131)
-				(xy 156.469752 105.9495) (xy 156.469748 105.9495) (xy 155.630252 105.9495) (xy 155.630247 105.9495)
-				(xy 155.57177 105.961131) (xy 155.571769 105.961132) (xy 155.505447 106.005447) (xy 155.461132 106.071769)
-				(xy 155.459556 106.079694) (xy 155.427169 106.141604) (xy 155.366453 106.176177) (xy 155.337939 106.1795)
-				(xy 155.045331 106.1795) (xy 154.978292 106.159815) (xy 154.95765 106.143181) (xy 154.880404 106.065935)
-				(xy 154.835835 106.045152) (xy 154.773173 106.015932) (xy 154.773171 106.015931) (xy 154.773172 106.015931)
-				(xy 154.724317 106.0095) (xy 154.724316 106.0095) (xy 154.275684 106.0095) (xy 154.275683 106.0095)
-				(xy 154.226828 106.015931) (xy 154.119595 106.065935) (xy 154.035935 106.149595) (xy 154.030298 106.161684)
-				(xy 153.98781 106.252801) (xy 153.981923 106.265425) (xy 153.980299 106.264668) (xy 153.948782 106.313915)
-				(xy 153.885281 106.34306) (xy 153.816104 106.333247) (xy 153.763213 106.287592) (xy 153.75502 106.272761)
-				(xy 153.747118 106.255815) (xy 153.703224 106.161684) (xy 153.618316 106.076776) (xy 153.618314 106.076774)
-				(xy 153.609427 106.070551) (xy 153.610797 106.068593) (xy 153.609068 106.06707) (xy 153.593297 106.059868)
-				(xy 153.583393 106.044458) (xy 153.569647 106.032351) (xy 153.564764 106.015469) (xy 153.555523 106.00109)
-				(xy 153.5505 105.966155) (xy 153.5505 105.763843) (xy 153.570185 105.696804) (xy 153.610767 105.661358)
-				(xy 153.609429 105.659447) (xy 153.618313 105.653225) (xy 153.618316 105.653224) (xy 153.703224 105.568316)
-				(xy 153.703224 105.568315) (xy 153.704721 105.566819) (xy 153.731648 105.552115) (xy 153.757467 105.535523)
-				(xy 153.763667 105.534631) (xy 153.766044 105.533334) (xy 153.792402 105.5305) (xy 153.936442 105.5305)
-				(xy 154.003481 105.550185) (xy 154.027616 105.57338) (xy 154.028264 105.572733) (xy 154.035935 105.580404)
-				(xy 154.119596 105.664065) (xy 154.226827 105.714068) (xy 154.275683 105.7205) (xy 154.275684 105.7205)
-				(xy 154.724317 105.7205) (xy 154.740601 105.718356) (xy 154.773173 105.714068) (xy 154.880404 105.664065)
-				(xy 154.964065 105.580404) (xy 155.014068 105.473173) (xy 155.0205 105.424316) (xy 155.0205 105.075684)
-				(xy 155.019276 105.06639) (xy 155.014068 105.026828) (xy 155.014068 105.026827) (xy 154.964065 104.919596)
-				(xy 154.880404 104.835935) (xy 154.773173 104.785932) (xy 154.773171 104.785931) (xy 154.773172 104.785931)
-				(xy 154.724317 104.7795) (xy 154.724316 104.7795) (xy 154.275684 104.7795) (xy 154.275683 104.7795)
-				(xy 154.226828 104.785931) (xy 154.119597 104.835934) (xy 154.062349 104.893182) (xy 154.035418 104.907886)
-				(xy 154.009603 104.924477) (xy 154.0034 104.925368) (xy 154.001025 104.926666) (xy 153.974668 104.9295)
-				(xy 153.792402 104.9295) (xy 153.725363 104.909815) (xy 153.704721 104.893181) (xy 153.649221 104.837681)
-				(xy 153.615736 104.776358) (xy 153.62072 104.706666) (xy 153.649221 104.662319) (xy 153.658582 104.652958)
-				(xy 153.703224 104.608316) (xy 153.753972 104.499487) (xy 153.7605 104.449901) (xy 153.760499 104.0901)
-				(xy 153.753972 104.040513) (xy 153.703224 103.931684) (xy 153.618316 103.846776) (xy 153.509487 103.796028)
-				(xy 153.509485 103.796027) (xy 153.509486 103.796027) (xy 153.459902 103.7895) (xy 153.459901 103.7895)
-				(xy 153.4245 103.7895) (xy 153.357461 103.769815) (xy 153.311706 103.717011) (xy 153.3005 103.6655)
-				(xy 153.3005 103.288296) (xy 153.309939 103.240842) (xy 153.310238 103.24012) (xy 153.31024 103.240117)
-				(xy 153.3255 103.163401) (xy 153.325499 102.3616) (xy 153.31024 102.284883) (xy 153.310239 102.284881)
-				(xy 153.310238 102.284879) (xy 153.273678 102.230164) (xy 153.252112 102.197888) (xy 153.165117 102.13976)
-				(xy 153.165115 102.139759) (xy 153.165112 102.139758) (xy 153.088404 102.1245) (xy 152.911601 102.1245)
-				(xy 152.83488 102.13976) (xy 152.818889 102.150446) (xy 152.752212 102.171323) (xy 152.684832 102.152837)
-				(xy 152.681111 102.150446) (xy 152.665117 102.139759) (xy 152.588403 102.1245) (xy 152.411601 102.1245)
-				(xy 152.334881 102.13976) (xy 152.334877 102.139762) (xy 152.318888 102.150446) (xy 152.252211 102.171323)
-				(xy 152.216978 102.166865) (xy 152.197719 102.161544) (xy 152.165117 102.13976) (xy 152.088401 102.1245)
-				(xy 152.063634 102.1245) (xy 152.047425 102.120022) (xy 152.031446 102.110112) (xy 152.013407 102.104815)
-				(xy 152.00147 102.09152) (xy 151.988048 102.083196) (xy 151.981329 102.069087) (xy 151.969537 102.055954)
-				(xy 151.966058 102.048995) (xy 151.96359 102.04406) (xy 151.951448 101.992627) (xy 151.951096 101.992662)
-				(xy 151.950837 101.990041) (xy 151.950499 101.988606) (xy 151.950499 101.986602) (xy 151.950499 101.9866)
-				(xy 151.93524 101.909883) (xy 151.935239 101.909881) (xy 151.935238 101.909878) (xy 151.924555 101.893891)
-				(xy 151.903676 101.827214) (xy 151.92216 101.759833) (xy 151.924517 101.756164) (xy 151.93524 101.740117)
-				(xy 151.9505 101.663401) (xy 151.950499 101.4866) (xy 151.93524 101.409883) (xy 151.935239 101.409881)
-				(xy 151.935238 101.409878) (xy 151.924555 101.393891) (xy 151.903676 101.327214) (xy 151.92216 101.259833)
-				(xy 151.924517 101.256164) (xy 151.93524 101.240117) (xy 151.9505 101.163401) (xy 151.950499 100.9866)
-				(xy 151.93524 100.909883) (xy 151.935239 100.909881) (xy 151.935238 100.909879) (xy 151.899562 100.856487)
-				(xy 151.877112 100.822888) (xy 151.790117 100.76476) (xy 151.790115 100.764759) (xy 151.790112 100.764758)
-				(xy 151.713404 100.7495) (xy 150.911602 100.7495) (xy 150.861273 100.759511) (xy 150.834883 100.76476)
-				(xy 150.834882 100.76476) (xy 150.834879 100.764761) (xy 150.834151 100.765063) (xy 150.825976 100.766688)
-				(xy 150.821638 100.769477) (xy 150.786703 100.7745) (xy 150.594154 100.7745) (xy 150.527115 100.754815)
-				(xy 150.481772 100.702905) (xy 150.471099 100.680017) (xy 150.453224 100.641684) (xy 150.368316 100.556776)
-				(xy 150.259487 100.506028) (xy 150.259485 100.506027) (xy 150.259486 100.506027) (xy 150.209901 100.4995)
-				(xy 149.790105 100.4995) (xy 149.774386 100.501569) (xy 149.740513 100.506028) (xy 149.740511 100.506029)
-				(xy 149.740509 100.506029) (xy 149.631683 100.556776) (xy 149.546776 100.641683) (xy 149.496027 100.750514)
-				(xy 149.4895 100.800097) (xy 149.4895 101.159894) (xy 149.490772 101.16956) (xy 149.496028 101.209487)
-				(xy 149.496029 101.209489) (xy 149.496029 101.20949) (xy 149.546776 101.318316) (xy 149.630779 101.402319)
-				(xy 149.664264 101.463642) (xy 149.65928 101.533334) (xy 149.630779 101.577681) (xy 149.546776 101.661683)
-				(xy 149.496027 101.770514) (xy 149.4895 101.820097) (xy 149.4895 102.179894) (xy 149.489501 102.1799)
-				(xy 149.494086 102.214739) (xy 148.4 103.4) (xy 144 106) (xy 137.5 106.5) (xy 135 105.5) (xy 134 104)
-				(xy 135.3 104) (xy 138 103.4) (xy 138.276 103.4) (xy 138.343039 103.419685) (xy 138.388794 103.472489)
-				(xy 138.4 103.524) (xy 138.4 104.2) (xy 138.838 104.2) (xy 138.846685 104.20255) (xy 138.855647 104.201262)
-				(xy 138.879687 104.21224) (xy 138.905039 104.219685) (xy 138.910966 104.226525) (xy 138.919203 104.230287)
-				(xy 138.933492 104.252521) (xy 138.950794 104.272489) (xy 138.953081 104.283003) (xy 138.956977 104.289065)
-				(xy 138.962 104.324) (xy 138.962 104.3255) (xy 138.942315 104.392539) (xy 138.889511 104.438294)
-				(xy 138.838 104.4495) (xy 137.662628 104.4495) (xy 137.595589 104.429815) (xy 137.555241 104.3875)
-				(xy 137.55004 104.378491) (xy 137.5005 104.292686) (xy 137.407314 104.1995) (xy 137.344995 104.16352)
-				(xy 137.293187 104.133608) (xy 137.212543 104.112) (xy 137.165892 104.0995) (xy 137.034108 104.0995)
-				(xy 136.906812 104.133608) (xy 136.792686 104.1995) (xy 136.792683 104.199502) (xy 136.787681 104.204505)
-				(xy 136.726358 104.23799) (xy 136.656666 104.233006) (xy 136.612319 104.204505) (xy 136.607316 104.199502)
-				(xy 136.607314 104.1995) (xy 136.544995 104.16352) (xy 136.493187 104.133608) (xy 136.412543 104.112)
-				(xy 136.365892 104.0995) (xy 136.234108 104.0995) (xy 136.106812 104.133608) (xy 135.992686 104.1995)
-				(xy 135.992683 104.199502) (xy 135.899502 104.292683) (xy 135.8995 104.292686) (xy 135.833608 104.406812)
-				(xy 135.807575 104.50397) (xy 135.7995 104.534108) (xy 135.7995 104.665892) (xy 135.813544 104.718304)
-				(xy 135.833608 104.793187) (xy 135.858289 104.835935) (xy 135.8995 104.907314) (xy 135.992686 105.0005)
-				(xy 136.106814 105.066392) (xy 136.202014 105.0919) (xy 136.2576 105.123993) (xy 136.494087 105.36048)
-				(xy 136.585412 105.413207) (xy 136.687273 105.4405) (xy 137.214167 105.4405) (xy 137.281206 105.460185)
-				(xy 137.301848 105.476819) (xy 137.315489 105.49046) (xy 137.315491 105.490461) (xy 137.315495 105.490464)
-				(xy 137.351862 105.51146) (xy 137.384011 105.530021) (xy 137.460438 105.5505) (xy 137.46044 105.5505)
-				(xy 139.28956 105.5505) (xy 139.289562 105.5505) (xy 139.365989 105.530021) (xy 139.434511 105.49046)
-				(xy 139.49046 105.434511) (xy 139.530021 105.365989) (xy 139.5505 105.289562) (xy 139.5505 104.860037)
-				(xy 139.554725 104.827943) (xy 139.563 104.797062) (xy 139.563 104.324) (xy 139.56555 104.315314)
-				(xy 139.564262 104.306353) (xy 139.57524 104.282312) (xy 139.582685 104.256961) (xy 139.589525 104.251033)
-				(xy 139.593287 104.242797) (xy 139.615521 104.228507) (xy 139.635489 104.211206) (xy 139.646003 104.208918)
-				(xy 139.652065 104.205023) (xy 139.687 104.2) (xy 139.839818 104.2) (xy 139.906857 104.219685) (xy 139.952612 104.272489)
-				(xy 139.958927 104.294471) (xy 139.959897 104.294212) (xy 139.962 104.30206) (xy 139.962 104.302062)
-				(xy 139.963803 104.30879) (xy 139.982479 104.378491) (xy 139.982481 104.378494) (xy 140.01015 104.426417)
-				(xy 140.010154 104.426423) (xy 140.01539 104.435493) (xy 140.015405 104.435558) (xy 140.032 104.497488)
-				(xy 140.032 104.707598) (xy 140.012315 104.774637) (xy 139.995681 104.795279) (xy 139.909276 104.881683)
-				(xy 139.858527 104.990514) (xy 139.852 105.040098) (xy 139.852 105.459894) (xy 139.852549 105.464064)
-				(xy 139.858528 105.509487) (xy 139.858529 105.509489) (xy 139.858529 105.50949) (xy 139.887445 105.5715)
-				(xy 139.909276 105.618316) (xy 139.994184 105.703224) (xy 140.103013 105.753972) (xy 140.152599 105.7605)
-				(xy 140.5124 105.760499) (xy 140.561987 105.753972) (xy 140.670816 105.703224) (xy 140.755724 105.618316)
-				(xy 140.806472 105.509487) (xy 140.813 105.459901) (xy 140.812999 105.0401) (xy 140.806472 104.990513)
-				(xy 140.759323 104.889403) (xy 140.748832 104.820328) (xy 140.777351 104.756544) (xy 140.835828 104.718304)
-				(xy 140.871706 104.713) (xy 143.39706 104.713) (xy 143.397062 104.713) (xy 143.473489 104.692521)
-				(xy 143.542011 104.65296) (xy 143.59796 104.597011) (xy 143.668152 104.526819) (xy 143.729475 104.493334)
-				(xy 143.755833 104.4905) (xy 143.974317 104.4905) (xy 143.998 104.487382) (xy 144.023173 104.484068)
-				(xy 144.130404 104.434065) (xy 144.214065 104.350404) (xy 144.264068 104.243173) (xy 144.2705 104.194316)
-				(xy 144.2705 103.845684) (xy 144.269093 103.835) (xy 144.266809 103.81765) (xy 144.264068 103.796827)
-				(xy 144.214065 103.689596) (xy 144.130404 103.605935) (xy 144.122733 103.598264) (xy 144.125561 103.595435)
-				(xy 144.094843 103.557023) (xy 144.087635 103.487526) (xy 144.119143 103.425165) (xy 144.12203 103.422188)
-				(xy 144.129977 103.414263) (xy 144.130404 103.414065) (xy 144.20578 103.338688) (xy 144.236368 103.322045)
-				(xy 144.266968 103.305337) (xy 144.267064 103.305343) (xy 144.267149 103.305298) (xy 144.301763 103.307825)
-				(xy 144.33666 103.310321) (xy 144.336751 103.31038) (xy 144.336833 103.310386) (xy 144.337259 103.310706)
-				(xy 144.381008 103.338822) (xy 144.442686 103.4005) (xy 144.442689 103.400501) (xy 144.442692 103.400504)
-				(xy 144.493461 103.429815) (xy 144.527556 103.4495) (xy 144.536255 103.454522) (xy 144.584471 103.505088)
-				(xy 144.597695 103.573695) (xy 144.580159 103.621291) (xy 144.581361 103.621852) (xy 144.526027 103.740514)
-				(xy 144.5195 103.790098) (xy 144.5195 104.209894) (xy 144.519501 104.2099) (xy 144.526028 104.259487)
-				(xy 144.526029 104.259489) (xy 144.526029 104.25949) (xy 144.556111 104.324) (xy 144.576776 104.368316)
-				(xy 144.661684 104.453224) (xy 144.770513 104.503972) (xy 144.820099 104.5105) (xy 145.1799 104.510499)
-				(xy 145.229487 104.503972) (xy 145.338316 104.453224) (xy 145.423224 104.368316) (xy 145.473972 104.259487)
-				(xy 145.4805 104.209901) (xy 145.480499 103.887253) (xy 145.489145 103.857807) (xy 145.495667 103.827827)
-				(xy 145.499419 103.822813) (xy 145.500183 103.820215) (xy 145.516813 103.799578) (xy 145.542399 103.773992)
-				(xy 145.597982 103.741901) (xy 145.693186 103.716392) (xy 145.807314 103.6505) (xy 145.9005 103.557314)
-				(xy 145.966392 103.443186) (xy 146.0005 103.315892) (xy 146.0005 103.184108) (xy 145.966392 103.056814)
-				(xy 145.96639 103.05681) (xy 145.966332 103.056594) (xy 145.967995 102.986744) (xy 146.007157 102.928881)
-				(xy 146.071386 102.901377) (xy 146.086107 102.9005) (xy 146.270761 102.9005) (xy 146.293471 102.897191)
-				(xy 146.338893 102.890573) (xy 146.443983 102.839198) (xy 146.526698 102.756483) (xy 146.578073 102.651393)
-				(xy 146.578073 102.651391) (xy 146.578074 102.65139) (xy 146.580916 102.642193) (xy 146.583032 102.642846)
-				(xy 146.606724 102.591209) (xy 146.665568 102.553538) (xy 146.735438 102.55366) (xy 146.787976 102.584895)
-				(xy 146.843541 102.64046) (xy 146.843543 102.640461) (xy 146.843547 102.640464) (xy 146.894006 102.669596)
-				(xy 146.912063 102.680021) (xy 146.98849 102.7005) (xy 147.067614 102.7005) (xy 147.094503 102.7005)
-				(xy 147.161542 102.720185) (xy 147.195423 102.75245) (xy 147.198305 102.756487) (xy 147.281014 102.839196)
-				(xy 147.281015 102.839196) (xy 147.281017 102.839198) (xy 147.386107 102.890573) (xy 147.420173 102.895536)
-				(xy 147.454239 102.9005) (xy 147.45424 102.9005) (xy 148.545761 102.9005) (xy 148.568471 102.897191)
-				(xy 148.613893 102.890573) (xy 148.718983 102.839198) (xy 148.801698 102.756483) (xy 148.853073 102.651393)
-				(xy 148.863 102.58326) (xy 148.863 102.21674) (xy 148.853073 102.148607) (xy 148.801698 102.043517)
-				(xy 148.801696 102.043515) (xy 148.801696 102.043514) (xy 148.718985 101.960803) (xy 148.613891 101.909426)
-				(xy 148.545761 101.8995) (xy 148.54576 101.8995) (xy 147.45424 101.8995) (xy 147.454239 101.8995)
-				(xy 147.386108 101.909426) (xy 147.281014 101.960803) (xy 147.2351 102.006717) (xy 147.173777 102.040201)
-				(xy 147.104085 102.035216) (xy 147.059739 102.006716) (xy 146.332564 101.279541) (xy 146.332559 101.279537)
-				(xy 146.322238 101.273579) (xy 146.316815 101.270448) (xy 146.264041 101.239979) (xy 146.254934 101.237538)
-				(xy 146.242409 101.230861) (xy 146.227189 101.215943) (xy 146.208995 101.204854) (xy 146.202738 101.191976)
-				(xy 146.192512 101.181952) (xy 146.187774 101.161173) (xy 146.178463 101.142008) (xy 146.180162 101.127791)
-				(xy 146.176979 101.113831) (xy 146.184225 101.093791) (xy 146.186755 101.072632) (xy 146.19587 101.06159)
-				(xy 146.20074 101.048126) (xy 146.21767 101.035185) (xy 146.231237 101.018753) (xy 146.247337 101.01251)
-				(xy 146.256252 101.005697) (xy 146.267218 101.004802) (xy 146.282864 100.998736) (xy 146.338893 100.990573)
-				(xy 146.443983 100.939198) (xy 146.526698 100.856483) (xy 146.578073 100.751393) (xy 146.588 100.68326)
-				(xy 146.588 100.31674) (xy 146.587393 100.312577) (xy 146.581846 100.2745) (xy 146.578073 100.248607)
-				(xy 146.526698 100.143517) (xy 146.526696 100.143515) (xy 146.526696 100.143514) (xy 146.443985 100.060803)
-				(xy 146.338891 100.009426) (xy 146.270761 99.9995) (xy 146.27076 99.9995) (xy 146.1745 99.9995)
-				(xy 146.107461 99.979815) (xy 146.061706 99.927011) (xy 146.0505 99.8755) (xy 146.0505 99.295331)
-				(xy 146.070185 99.228292) (xy 146.086819 99.20765) (xy 146.119969 99.1745) (xy 146.164065 99.130404)
-				(xy 146.214068 99.023173) (xy 146.2205 98.974316) (xy 146.2205 98.525684) (xy 146.214068 98.476827)
-				(xy 146.164065 98.369596) (xy 146.080404 98.285935) (xy 145.973173 98.235932) (xy 145.973171 98.235931)
-				(xy 145.973172 98.235931) (xy 145.924317 98.2295) (xy 145.924316 98.2295) (xy 145.575684 98.2295)
-				(xy 145.575683 98.2295) (xy 145.526828 98.235931) (xy 145.419595 98.285935) (xy 145.335935 98.369595)
-				(xy 145.285931 98.476828) (xy 145.2795 98.525683) (xy 145.2795 98.974316) (xy 145.285931 99.023171)
-				(xy 145.335935 99.130404) (xy 145.413181 99.20765) (xy 145.446666 99.268973) (xy 145.4495 99.295331)
-				(xy 145.4495 99.8755) (xy 145.429815 99.942539) (xy 145.377011 99.988294) (xy 145.3255 99.9995)
-				(xy 145.179239 99.9995) (xy 145.111108 100.009426) (xy 145.006014 100.060803) (xy 144.923305 100.143512)
-				(xy 144.920423 100.14755) (xy 144.865449 100.190674) (xy 144.819503 100.1995) (xy 144.295331 100.1995)
-				(xy 144.228292 100.179815) (xy 144.20765 100.163181) (xy 144.130404 100.085935) (xy 144.09648 100.070116)
-				(xy 144.023173 100.035932) (xy 144.023171 100.035931) (xy 144.023172 100.035931) (xy 143.974317 100.0295)
-				(xy 143.974316 100.0295) (xy 143.525684 100.0295) (xy 143.525683 100.0295) (xy 143.476828 100.035931)
-				(xy 143.369595 100.085935) (xy 143.285935 100.169595) (xy 143.235931 100.276828) (xy 143.2295 100.325683)
-				(xy 143.2295 100.674316) (xy 143.235931 100.723171) (xy 143.285935 100.830404) (xy 143.377267 100.921736)
-				(xy 143.374443 100.924559) (xy 143.405183 100.963042) (xy 143.412352 101.032542) (xy 143.380808 101.094886)
-				(xy 143.377101 101.098098) (xy 143.377267 101.098264) (xy 143.285935 101.189595) (xy 143.235931 101.296828)
-				(xy 143.2295 101.345683) (xy 143.2295 101.694316) (xy 143.235931 101.743171) (xy 143.271803 101.820099)
-				(xy 143.285935 101.850404) (xy 143.369596 101.934065) (xy 143.377904 101.937939) (xy 143.430343 101.98411)
-				(xy 143.4495 102.050321) (xy 143.4495 102.469677) (xy 143.429815 102.536716) (xy 143.377911 102.582056)
-				(xy 143.369598 102.585932) (xy 143.285935 102.669595) (xy 143.235931 102.776828) (xy 143.2295 102.825683)
-				(xy 143.2295 103.174316) (xy 143.235931 103.223171) (xy 143.285935 103.330404) (xy 143.377267 103.421736)
-				(xy 143.374443 103.424559) (xy 143.405183 103.463042) (xy 143.412352 103.532542) (xy 143.380808 103.594886)
-				(xy 143.377101 103.598098) (xy 143.377267 103.598264) (xy 143.285935 103.689595) (xy 143.235931 103.796828)
-				(xy 143.2295 103.845683) (xy 143.2295 103.988) (xy 143.209815 104.055039) (xy 143.157011 104.100794)
-				(xy 143.1055 104.112) (xy 141.824 104.112) (xy 141.756961 104.092315) (xy 141.711206 104.039511)
-				(xy 141.7 103.988) (xy 141.7 103.524) (xy 141.719685 103.456961) (xy 141.772489 103.411206) (xy 141.824 103.4)
-				(xy 142.5 103.4) (xy 142.5 100.1) (xy 141.824 100.1) (xy 141.756961 100.080315) (xy 141.711206 100.027511)
-				(xy 141.7 99.976) (xy 141.7 99.2) (xy 138.4 99.2) (xy 138.4 99.976) (xy 138.380315 100.043039) (xy 138.327511 100.088794)
-				(xy 138.276 100.1) (xy 138 100.1) (xy 138 100) (xy 122.5005 100) (xy 122.5005 94.800002) (xy 129.1945 94.800002)
-				(xy 129.1945 97.099997) (xy 129.195802 97.128183) (xy 129.195804 97.128192) (xy 129.226526 97.236169)
-				(xy 129.226527 97.236171) (xy 129.226528 97.236173) (xy 129.294123 97.325684) (xy 129.294186 97.325767)
-				(xy 129.389639 97.384869) (xy 129.389641 97.38487) (xy 129.5 97.4055) (xy 129.500002 97.4055) (xy 130.3705 97.4055)
-				(xy 130.437539 97.425185) (xy 130.483294 97.477989) (xy 130.4945 97.5295) (xy 130.4945 98.099997)
-				(xy 130.495802 98.128183) (xy 130.495804 98.128192) (xy 130.526526 98.236169) (xy 130.526527 98.236171)
-				(xy 130.526528 98.236173) (xy 130.579118 98.305814) (xy 130.594186 98.325767) (xy 130.689639 98.384869)
-				(xy 130.689641 98.38487) (xy 130.8 98.4055) (xy 130.800002 98.4055) (xy 132.299998 98.4055) (xy 132.3 98.4055)
-				(xy 132.328188 98.404197) (xy 132.436173 98.373472) (xy 132.525767 98.305814) (xy 132.58487 98.210359)
-				(xy 132.6055 98.1) (xy 132.6055 96.3) (xy 132.604197 96.271812) (xy 132.573472 96.163827) (xy 132.573471 96.163826)
+				(xy 156.638867 106.828231) (xy 156.638867 106.828229) (xy 156.638868 106.828229) (xy 156.649759 106.773472)
+				(xy 156.6505 106.769748) (xy 156.6505 106.130252) (xy 156.6505 106.130249) (xy 156.650499 106.130247)
+				(xy 156.638868 106.07177) (xy 156.638867 106.071769) (xy 156.594552 106.005447) (xy 156.52823 105.961132)
+				(xy 156.528229 105.961131) (xy 156.469752 105.9495) (xy 156.469748 105.9495) (xy 155.630252 105.9495)
+				(xy 155.630247 105.9495) (xy 155.57177 105.961131) (xy 155.571769 105.961132) (xy 155.505447 106.005447)
+				(xy 155.461132 106.071769) (xy 155.459556 106.079694) (xy 155.427169 106.141604) (xy 155.366453 106.176177)
+				(xy 155.337939 106.1795) (xy 155.045331 106.1795) (xy 154.978292 106.159815) (xy 154.95765 106.143181)
+				(xy 154.880404 106.065935) (xy 154.835835 106.045152) (xy 154.773173 106.015932) (xy 154.773171 106.015931)
+				(xy 154.773172 106.015931) (xy 154.724317 106.0095) (xy 154.724316 106.0095) (xy 154.275684 106.0095)
+				(xy 154.275683 106.0095) (xy 154.226828 106.015931) (xy 154.119595 106.065935) (xy 154.035935 106.149595)
+				(xy 153.981923 106.265425) (xy 153.980299 106.264668) (xy 153.948782 106.313915) (xy 153.885281 106.34306)
+				(xy 153.816104 106.333247) (xy 153.763213 106.287592) (xy 153.75502 106.272761) (xy 153.735644 106.231209)
+				(xy 153.703224 106.161684) (xy 153.618316 106.076776) (xy 153.618314 106.076774) (xy 153.609427 106.070551)
+				(xy 153.610797 106.068593) (xy 153.609068 106.06707) (xy 153.593297 106.059868) (xy 153.583393 106.044458)
+				(xy 153.569647 106.032351) (xy 153.564764 106.015469) (xy 153.555523 106.00109) (xy 153.5505 105.966155)
+				(xy 153.5505 105.763843) (xy 153.570185 105.696804) (xy 153.610767 105.661358) (xy 153.609429 105.659447)
+				(xy 153.618313 105.653225) (xy 153.618316 105.653224) (xy 153.703224 105.568316) (xy 153.703224 105.568315)
+				(xy 153.704721 105.566819) (xy 153.731648 105.552115) (xy 153.757467 105.535523) (xy 153.763667 105.534631)
+				(xy 153.766044 105.533334) (xy 153.792402 105.5305) (xy 153.936442 105.5305) (xy 154.003481 105.550185)
+				(xy 154.027616 105.57338) (xy 154.028264 105.572733) (xy 154.035935 105.580404) (xy 154.119596 105.664065)
+				(xy 154.226827 105.714068) (xy 154.275683 105.7205) (xy 154.275684 105.7205) (xy 154.724317 105.7205)
+				(xy 154.740601 105.718356) (xy 154.773173 105.714068) (xy 154.880404 105.664065) (xy 154.964065 105.580404)
+				(xy 155.014068 105.473173) (xy 155.0205 105.424316) (xy 155.0205 105.075684) (xy 155.019276 105.06639)
+				(xy 155.014068 105.026828) (xy 155.014068 105.026827) (xy 154.964065 104.919596) (xy 154.880404 104.835935)
+				(xy 154.773173 104.785932) (xy 154.773171 104.785931) (xy 154.773172 104.785931) (xy 154.724317 104.7795)
+				(xy 154.724316 104.7795) (xy 154.275684 104.7795) (xy 154.275683 104.7795) (xy 154.226828 104.785931)
+				(xy 154.119597 104.835934) (xy 154.062349 104.893182) (xy 154.035418 104.907886) (xy 154.009603 104.924477)
+				(xy 154.0034 104.925368) (xy 154.001025 104.926666) (xy 153.974668 104.9295) (xy 153.792402 104.9295)
+				(xy 153.725363 104.909815) (xy 153.704721 104.893181) (xy 153.649221 104.837681) (xy 153.615736 104.776358)
+				(xy 153.62072 104.706666) (xy 153.649221 104.662319) (xy 153.658582 104.652958) (xy 153.703224 104.608316)
+				(xy 153.753972 104.499487) (xy 153.7605 104.449901) (xy 153.760499 104.0901) (xy 153.753972 104.040513)
+				(xy 153.703224 103.931684) (xy 153.618316 103.846776) (xy 153.509487 103.796028) (xy 153.509485 103.796027)
+				(xy 153.509486 103.796027) (xy 153.459902 103.7895) (xy 153.459901 103.7895) (xy 153.4245 103.7895)
+				(xy 153.357461 103.769815) (xy 153.311706 103.717011) (xy 153.3005 103.6655) (xy 153.3005 103.288296)
+				(xy 153.309939 103.240842) (xy 153.310238 103.24012) (xy 153.31024 103.240117) (xy 153.3255 103.163401)
+				(xy 153.325499 102.3616) (xy 153.31024 102.284883) (xy 153.310239 102.284881) (xy 153.310238 102.284879)
+				(xy 153.273678 102.230164) (xy 153.252112 102.197888) (xy 153.165117 102.13976) (xy 153.165115 102.139759)
+				(xy 153.165112 102.139758) (xy 153.088404 102.1245) (xy 152.911601 102.1245) (xy 152.83488 102.13976)
+				(xy 152.818889 102.150446) (xy 152.752212 102.171323) (xy 152.684832 102.152837) (xy 152.681111 102.150446)
+				(xy 152.665117 102.139759) (xy 152.588403 102.1245) (xy 152.411601 102.1245) (xy 152.334881 102.13976)
+				(xy 152.334877 102.139762) (xy 152.318888 102.150446) (xy 152.252211 102.171323) (xy 152.216978 102.166865)
+				(xy 152.197719 102.161544) (xy 152.165117 102.13976) (xy 152.088401 102.1245) (xy 152.063634 102.1245)
+				(xy 152.047425 102.120022) (xy 152.031446 102.110112) (xy 152.013407 102.104815) (xy 152.00147 102.09152)
+				(xy 151.988048 102.083196) (xy 151.981329 102.069087) (xy 151.969537 102.055954) (xy 151.966058 102.048995)
+				(xy 151.96359 102.04406) (xy 151.951448 101.992627) (xy 151.951096 101.992662) (xy 151.950837 101.990041)
+				(xy 151.950499 101.988606) (xy 151.950499 101.986602) (xy 151.950499 101.9866) (xy 151.93524 101.909883)
+				(xy 151.935239 101.909881) (xy 151.935238 101.909878) (xy 151.924555 101.893891) (xy 151.903676 101.827214)
+				(xy 151.92216 101.759833) (xy 151.924517 101.756164) (xy 151.93524 101.740117) (xy 151.9505 101.663401)
+				(xy 151.950499 101.4866) (xy 151.93524 101.409883) (xy 151.935239 101.409881) (xy 151.935238 101.409878)
+				(xy 151.924555 101.393891) (xy 151.903676 101.327214) (xy 151.92216 101.259833) (xy 151.924517 101.256164)
+				(xy 151.93524 101.240117) (xy 151.9505 101.163401) (xy 151.950499 100.9866) (xy 151.93524 100.909883)
+				(xy 151.935239 100.909881) (xy 151.935238 100.909879) (xy 151.899562 100.856487) (xy 151.877112 100.822888)
+				(xy 151.790117 100.76476) (xy 151.790115 100.764759) (xy 151.790112 100.764758) (xy 151.713404 100.7495)
+				(xy 150.911602 100.7495) (xy 150.861273 100.759511) (xy 150.834883 100.76476) (xy 150.834882 100.76476)
+				(xy 150.834879 100.764761) (xy 150.834151 100.765063) (xy 150.825976 100.766688) (xy 150.821638 100.769477)
+				(xy 150.786703 100.7745) (xy 150.594154 100.7745) (xy 150.527115 100.754815) (xy 150.481772 100.702905)
+				(xy 150.471099 100.680017) (xy 150.453224 100.641684) (xy 150.368316 100.556776) (xy 150.259487 100.506028)
+				(xy 150.259485 100.506027) (xy 150.259486 100.506027) (xy 150.209901 100.4995) (xy 149.790105 100.4995)
+				(xy 149.774386 100.501569) (xy 149.740513 100.506028) (xy 149.740511 100.506029) (xy 149.740509 100.506029)
+				(xy 149.631683 100.556776) (xy 149.546776 100.641683) (xy 149.496027 100.750514) (xy 149.4895 100.800097)
+				(xy 149.4895 101.159894) (xy 149.490772 101.16956) (xy 149.496028 101.209487) (xy 149.496029 101.209489)
+				(xy 149.496029 101.20949) (xy 149.546776 101.318316) (xy 149.630779 101.402319) (xy 149.664264 101.463642)
+				(xy 149.65928 101.533334) (xy 149.630779 101.577681) (xy 149.546776 101.661683) (xy 149.496027 101.770514)
+				(xy 149.4895 101.820097) (xy 149.4895 102.179894) (xy 149.489501 102.1799) (xy 149.494086 102.214739)
+				(xy 148.4 103.4) (xy 144 106) (xy 137.5 106.5) (xy 135 105.5) (xy 134 104) (xy 135.3 104) (xy 138 103.4)
+				(xy 138.276 103.4) (xy 138.343039 103.419685) (xy 138.388794 103.472489) (xy 138.4 103.524) (xy 138.4 104.2)
+				(xy 138.838 104.2) (xy 138.846685 104.20255) (xy 138.855647 104.201262) (xy 138.879687 104.21224)
+				(xy 138.905039 104.219685) (xy 138.910966 104.226525) (xy 138.919203 104.230287) (xy 138.933492 104.252521)
+				(xy 138.950794 104.272489) (xy 138.953081 104.283003) (xy 138.956977 104.289065) (xy 138.962 104.324)
+				(xy 138.962 104.3255) (xy 138.942315 104.392539) (xy 138.889511 104.438294) (xy 138.838 104.4495)
+				(xy 137.662628 104.4495) (xy 137.595589 104.429815) (xy 137.555241 104.3875) (xy 137.55004 104.378491)
+				(xy 137.5005 104.292686) (xy 137.407314 104.1995) (xy 137.344995 104.16352) (xy 137.293187 104.133608)
+				(xy 137.212543 104.112) (xy 137.165892 104.0995) (xy 137.034108 104.0995) (xy 136.906812 104.133608)
+				(xy 136.792686 104.1995) (xy 136.792683 104.199502) (xy 136.787681 104.204505) (xy 136.726358 104.23799)
+				(xy 136.656666 104.233006) (xy 136.612319 104.204505) (xy 136.607316 104.199502) (xy 136.607314 104.1995)
+				(xy 136.544995 104.16352) (xy 136.493187 104.133608) (xy 136.412543 104.112) (xy 136.365892 104.0995)
+				(xy 136.234108 104.0995) (xy 136.106812 104.133608) (xy 135.992686 104.1995) (xy 135.992683 104.199502)
+				(xy 135.899502 104.292683) (xy 135.8995 104.292686) (xy 135.833608 104.406812) (xy 135.807575 104.50397)
+				(xy 135.7995 104.534108) (xy 135.7995 104.665892) (xy 135.813544 104.718304) (xy 135.833608 104.793187)
+				(xy 135.858289 104.835935) (xy 135.8995 104.907314) (xy 135.992686 105.0005) (xy 136.106814 105.066392)
+				(xy 136.202014 105.0919) (xy 136.2576 105.123993) (xy 136.494087 105.36048) (xy 136.585412 105.413207)
+				(xy 136.687273 105.4405) (xy 137.214167 105.4405) (xy 137.281206 105.460185) (xy 137.301848 105.476819)
+				(xy 137.315489 105.49046) (xy 137.315491 105.490461) (xy 137.315495 105.490464) (xy 137.351862 105.51146)
+				(xy 137.384011 105.530021) (xy 137.460438 105.5505) (xy 137.46044 105.5505) (xy 139.28956 105.5505)
+				(xy 139.289562 105.5505) (xy 139.365989 105.530021) (xy 139.434511 105.49046) (xy 139.49046 105.434511)
+				(xy 139.530021 105.365989) (xy 139.5505 105.289562) (xy 139.5505 104.860037) (xy 139.554725 104.827943)
+				(xy 139.563 104.797062) (xy 139.563 104.324) (xy 139.56555 104.315314) (xy 139.564262 104.306353)
+				(xy 139.57524 104.282312) (xy 139.582685 104.256961) (xy 139.589525 104.251033) (xy 139.593287 104.242797)
+				(xy 139.615521 104.228507) (xy 139.635489 104.211206) (xy 139.646003 104.208918) (xy 139.652065 104.205023)
+				(xy 139.687 104.2) (xy 139.839818 104.2) (xy 139.906857 104.219685) (xy 139.952612 104.272489) (xy 139.958927 104.294471)
+				(xy 139.959897 104.294212) (xy 139.962 104.30206) (xy 139.962 104.302062) (xy 139.963803 104.30879)
+				(xy 139.982479 104.378491) (xy 139.982481 104.378494) (xy 140.01015 104.426417) (xy 140.010154 104.426423)
+				(xy 140.01539 104.435493) (xy 140.015405 104.435558) (xy 140.032 104.497488) (xy 140.032 104.707598)
+				(xy 140.012315 104.774637) (xy 139.995681 104.795279) (xy 139.909276 104.881683) (xy 139.858527 104.990514)
+				(xy 139.852 105.040098) (xy 139.852 105.459894) (xy 139.852549 105.464064) (xy 139.858528 105.509487)
+				(xy 139.858529 105.509489) (xy 139.858529 105.50949) (xy 139.887445 105.5715) (xy 139.909276 105.618316)
+				(xy 139.994184 105.703224) (xy 140.103013 105.753972) (xy 140.152599 105.7605) (xy 140.5124 105.760499)
+				(xy 140.561987 105.753972) (xy 140.670816 105.703224) (xy 140.755724 105.618316) (xy 140.806472 105.509487)
+				(xy 140.813 105.459901) (xy 140.812999 105.0401) (xy 140.806472 104.990513) (xy 140.759323 104.889403)
+				(xy 140.748832 104.820328) (xy 140.777351 104.756544) (xy 140.835828 104.718304) (xy 140.871706 104.713)
+				(xy 143.39706 104.713) (xy 143.397062 104.713) (xy 143.473489 104.692521) (xy 143.542011 104.65296)
+				(xy 143.59796 104.597011) (xy 143.668152 104.526819) (xy 143.729475 104.493334) (xy 143.755833 104.4905)
+				(xy 143.974317 104.4905) (xy 143.998 104.487382) (xy 144.023173 104.484068) (xy 144.130404 104.434065)
+				(xy 144.214065 104.350404) (xy 144.264068 104.243173) (xy 144.2705 104.194316) (xy 144.2705 103.845684)
+				(xy 144.269093 103.835) (xy 144.266809 103.81765) (xy 144.264068 103.796827) (xy 144.214065 103.689596)
+				(xy 144.130404 103.605935) (xy 144.122733 103.598264) (xy 144.125561 103.595435) (xy 144.094843 103.557023)
+				(xy 144.087635 103.487526) (xy 144.119143 103.425165) (xy 144.12203 103.422188) (xy 144.129977 103.414263)
+				(xy 144.130404 103.414065) (xy 144.20578 103.338688) (xy 144.236368 103.322045) (xy 144.266968 103.305337)
+				(xy 144.267064 103.305343) (xy 144.267149 103.305298) (xy 144.301763 103.307825) (xy 144.33666 103.310321)
+				(xy 144.336751 103.31038) (xy 144.336833 103.310386) (xy 144.337259 103.310706) (xy 144.381008 103.338822)
+				(xy 144.442686 103.4005) (xy 144.442689 103.400501) (xy 144.442692 103.400504) (xy 144.500661 103.433972)
+				(xy 144.527556 103.4495) (xy 144.536255 103.454522) (xy 144.584471 103.505088) (xy 144.597695 103.573695)
+				(xy 144.580159 103.621291) (xy 144.581361 103.621852) (xy 144.526027 103.740514) (xy 144.5195 103.790098)
+				(xy 144.5195 104.209894) (xy 144.519501 104.2099) (xy 144.526028 104.259487) (xy 144.526029 104.259489)
+				(xy 144.526029 104.25949) (xy 144.556111 104.324) (xy 144.576776 104.368316) (xy 144.661684 104.453224)
+				(xy 144.770513 104.503972) (xy 144.820099 104.5105) (xy 145.1799 104.510499) (xy 145.229487 104.503972)
+				(xy 145.338316 104.453224) (xy 145.423224 104.368316) (xy 145.473972 104.259487) (xy 145.4805 104.209901)
+				(xy 145.480499 103.887253) (xy 145.489145 103.857807) (xy 145.495667 103.827827) (xy 145.499419 103.822813)
+				(xy 145.500183 103.820215) (xy 145.516813 103.799578) (xy 145.542399 103.773992) (xy 145.597982 103.741901)
+				(xy 145.693186 103.716392) (xy 145.807314 103.6505) (xy 145.9005 103.557314) (xy 145.966392 103.443186)
+				(xy 146.0005 103.315892) (xy 146.0005 103.184108) (xy 145.966392 103.056814) (xy 145.96639 103.05681)
+				(xy 145.966332 103.056594) (xy 145.967995 102.986744) (xy 146.007157 102.928881) (xy 146.071386 102.901377)
+				(xy 146.086107 102.9005) (xy 146.270761 102.9005) (xy 146.293471 102.897191) (xy 146.338893 102.890573)
+				(xy 146.443983 102.839198) (xy 146.526698 102.756483) (xy 146.578073 102.651393) (xy 146.578073 102.651391)
+				(xy 146.578074 102.65139) (xy 146.580916 102.642193) (xy 146.583032 102.642846) (xy 146.606724 102.591209)
+				(xy 146.665568 102.553538) (xy 146.735438 102.55366) (xy 146.787976 102.584895) (xy 146.843541 102.64046)
+				(xy 146.843543 102.640461) (xy 146.843547 102.640464) (xy 146.894006 102.669596) (xy 146.912063 102.680021)
+				(xy 146.98849 102.7005) (xy 147.067614 102.7005) (xy 147.094503 102.7005) (xy 147.161542 102.720185)
+				(xy 147.195423 102.75245) (xy 147.198305 102.756487) (xy 147.281014 102.839196) (xy 147.281015 102.839196)
+				(xy 147.281017 102.839198) (xy 147.386107 102.890573) (xy 147.420173 102.895536) (xy 147.454239 102.9005)
+				(xy 147.45424 102.9005) (xy 148.545761 102.9005) (xy 148.568471 102.897191) (xy 148.613893 102.890573)
+				(xy 148.718983 102.839198) (xy 148.801698 102.756483) (xy 148.853073 102.651393) (xy 148.863 102.58326)
+				(xy 148.863 102.21674) (xy 148.853073 102.148607) (xy 148.801698 102.043517) (xy 148.801696 102.043515)
+				(xy 148.801696 102.043514) (xy 148.718985 101.960803) (xy 148.613891 101.909426) (xy 148.545761 101.8995)
+				(xy 148.54576 101.8995) (xy 147.45424 101.8995) (xy 147.454239 101.8995) (xy 147.386108 101.909426)
+				(xy 147.281014 101.960803) (xy 147.2351 102.006717) (xy 147.173777 102.040201) (xy 147.104085 102.035216)
+				(xy 147.059739 102.006716) (xy 146.332564 101.279541) (xy 146.332559 101.279537) (xy 146.322238 101.273579)
+				(xy 146.316815 101.270448) (xy 146.264041 101.239979) (xy 146.254934 101.237538) (xy 146.242409 101.230861)
+				(xy 146.227189 101.215943) (xy 146.208995 101.204854) (xy 146.202738 101.191976) (xy 146.192512 101.181952)
+				(xy 146.187774 101.161173) (xy 146.178463 101.142008) (xy 146.180162 101.127791) (xy 146.176979 101.113831)
+				(xy 146.184225 101.093791) (xy 146.186755 101.072632) (xy 146.19587 101.06159) (xy 146.20074 101.048126)
+				(xy 146.21767 101.035185) (xy 146.231237 101.018753) (xy 146.247337 101.01251) (xy 146.256252 101.005697)
+				(xy 146.267218 101.004802) (xy 146.282864 100.998736) (xy 146.338893 100.990573) (xy 146.443983 100.939198)
+				(xy 146.526698 100.856483) (xy 146.578073 100.751393) (xy 146.588 100.68326) (xy 146.588 100.31674)
+				(xy 146.587393 100.312577) (xy 146.581846 100.2745) (xy 146.578073 100.248607) (xy 146.526698 100.143517)
+				(xy 146.526696 100.143515) (xy 146.526696 100.143514) (xy 146.443985 100.060803) (xy 146.338891 100.009426)
+				(xy 146.270761 99.9995) (xy 146.27076 99.9995) (xy 146.1745 99.9995) (xy 146.107461 99.979815) (xy 146.061706 99.927011)
+				(xy 146.0505 99.8755) (xy 146.0505 99.295331) (xy 146.070185 99.228292) (xy 146.086819 99.20765)
+				(xy 146.119969 99.1745) (xy 146.164065 99.130404) (xy 146.214068 99.023173) (xy 146.2205 98.974316)
+				(xy 146.2205 98.525684) (xy 146.214068 98.476827) (xy 146.164065 98.369596) (xy 146.080404 98.285935)
+				(xy 145.973173 98.235932) (xy 145.973171 98.235931) (xy 145.973172 98.235931) (xy 145.924317 98.2295)
+				(xy 145.924316 98.2295) (xy 145.575684 98.2295) (xy 145.575683 98.2295) (xy 145.526828 98.235931)
+				(xy 145.419595 98.285935) (xy 145.335935 98.369595) (xy 145.285931 98.476828) (xy 145.2795 98.525683)
+				(xy 145.2795 98.974316) (xy 145.285931 99.023171) (xy 145.335935 99.130404) (xy 145.413181 99.20765)
+				(xy 145.446666 99.268973) (xy 145.4495 99.295331) (xy 145.4495 99.8755) (xy 145.429815 99.942539)
+				(xy 145.377011 99.988294) (xy 145.3255 99.9995) (xy 145.179239 99.9995) (xy 145.111108 100.009426)
+				(xy 145.006014 100.060803) (xy 144.923305 100.143512) (xy 144.920423 100.14755) (xy 144.865449 100.190674)
+				(xy 144.819503 100.1995) (xy 144.295331 100.1995) (xy 144.228292 100.179815) (xy 144.20765 100.163181)
+				(xy 144.130404 100.085935) (xy 144.09648 100.070116) (xy 144.023173 100.035932) (xy 144.023171 100.035931)
+				(xy 144.023172 100.035931) (xy 143.974317 100.0295) (xy 143.974316 100.0295) (xy 143.525684 100.0295)
+				(xy 143.525683 100.0295) (xy 143.476828 100.035931) (xy 143.369595 100.085935) (xy 143.285935 100.169595)
+				(xy 143.235931 100.276828) (xy 143.2295 100.325683) (xy 143.2295 100.674316) (xy 143.235931 100.723171)
+				(xy 143.285935 100.830404) (xy 143.377267 100.921736) (xy 143.374443 100.924559) (xy 143.405183 100.963042)
+				(xy 143.412352 101.032542) (xy 143.380808 101.094886) (xy 143.377101 101.098098) (xy 143.377267 101.098264)
+				(xy 143.285935 101.189595) (xy 143.235931 101.296828) (xy 143.2295 101.345683) (xy 143.2295 101.694316)
+				(xy 143.235931 101.743171) (xy 143.271803 101.820099) (xy 143.285935 101.850404) (xy 143.369596 101.934065)
+				(xy 143.377904 101.937939) (xy 143.430343 101.98411) (xy 143.4495 102.050321) (xy 143.4495 102.469677)
+				(xy 143.429815 102.536716) (xy 143.377911 102.582056) (xy 143.369598 102.585932) (xy 143.285935 102.669595)
+				(xy 143.235931 102.776828) (xy 143.2295 102.825683) (xy 143.2295 103.174316) (xy 143.235931 103.223171)
+				(xy 143.285935 103.330404) (xy 143.377267 103.421736) (xy 143.374443 103.424559) (xy 143.405183 103.463042)
+				(xy 143.412352 103.532542) (xy 143.380808 103.594886) (xy 143.377101 103.598098) (xy 143.377267 103.598264)
+				(xy 143.285935 103.689595) (xy 143.235931 103.796828) (xy 143.2295 103.845683) (xy 143.2295 103.988)
+				(xy 143.209815 104.055039) (xy 143.157011 104.100794) (xy 143.1055 104.112) (xy 141.824 104.112)
+				(xy 141.756961 104.092315) (xy 141.711206 104.039511) (xy 141.7 103.988) (xy 141.7 103.524) (xy 141.719685 103.456961)
+				(xy 141.772489 103.411206) (xy 141.824 103.4) (xy 142.5 103.4) (xy 142.5 100.1) (xy 141.824 100.1)
+				(xy 141.756961 100.080315) (xy 141.711206 100.027511) (xy 141.7 99.976) (xy 141.7 99.2) (xy 138.4 99.2)
+				(xy 138.4 99.976) (xy 138.380315 100.043039) (xy 138.327511 100.088794) (xy 138.276 100.1) (xy 138 100.1)
+				(xy 138 100) (xy 122.5005 100) (xy 122.5005 94.800002) (xy 129.1945 94.800002) (xy 129.1945 97.099997)
+				(xy 129.195802 97.128183) (xy 129.195804 97.128192) (xy 129.226526 97.236169) (xy 129.226527 97.236171)
+				(xy 129.226528 97.236173) (xy 129.294123 97.325684) (xy 129.294186 97.325767) (xy 129.389639 97.384869)
+				(xy 129.389641 97.38487) (xy 129.5 97.4055) (xy 129.500002 97.4055) (xy 130.3705 97.4055) (xy 130.437539 97.425185)
+				(xy 130.483294 97.477989) (xy 130.4945 97.5295) (xy 130.4945 98.099997) (xy 130.495802 98.128183)
+				(xy 130.495804 98.128192) (xy 130.526526 98.236169) (xy 130.526527 98.236171) (xy 130.526528 98.236173)
+				(xy 130.579118 98.305814) (xy 130.594186 98.325767) (xy 130.689639 98.384869) (xy 130.689641 98.38487)
+				(xy 130.8 98.4055) (xy 130.800002 98.4055) (xy 132.299998 98.4055) (xy 132.3 98.4055) (xy 132.328188 98.404197)
+				(xy 132.436173 98.373472) (xy 132.525767 98.305814) (xy 132.58487 98.210359) (xy 132.6055 98.1)
+				(xy 132.6055 96.3) (xy 132.604197 96.271812) (xy 132.573472 96.163827) (xy 132.573471 96.163826)
 				(xy 132.573471 96.163825) (xy 132.528464 96.104227) (xy 132.503772 96.038866) (xy 132.518337 95.970531)
 				(xy 132.567534 95.920919) (xy 132.627418 95.9055) (xy 133.199998 95.9055) (xy 133.2 95.9055) (xy 133.228188 95.904197)
 				(xy 133.336173 95.873472) (xy 133.425767 95.805814) (xy 133.425767 95.805813) (xy 133.434936 95.79889)
@@ -35793,6 +35629,71 @@
 			)
 		)
 	)
+	(group "group-boardStackUp"
+		(uuid "40ac44ab-8063-4ce2-95e6-2b764d561ef3")
+		(members "01688c22-7566-4faa-99d7-d469eaa6c1b2" "01d1f9e6-98ea-4b52-939d-191f38c291da"
+			"022680d1-d839-4109-82f2-d911b9410d5f" "030859e9-be11-42ac-a7b7-1b3b603bedc2"
+			"03c7ff3d-99b6-4018-a7d1-399b94751cb6" "081b8de1-98ce-4ec8-8a49-c755fa188009"
+			"0a088c05-2b0f-4065-966a-406508862878" "0ae3316f-0ccc-40ff-8bad-72d96ed15f18"
+			"0b24fddd-1697-479d-9de5-36b6be2b6370" "0d463206-dc52-4e11-a5b2-496d79c56f8a"
+			"10956ede-d92e-404c-abaa-86f63d848aa4" "11751c9a-e71a-47a8-bb94-05e90868b334"
+			"138fd769-5f63-440c-9a8c-c779196af7cc" "143f4bf8-b146-4cbf-a4df-726297094628"
+			"14e96df1-d7fe-466d-8b4c-7bf458027bab" "163c28e4-9ef5-4160-91b4-4d71e3e576b3"
+			"1db1a463-a67e-4961-b4f7-d0b1478dd848" "20a6ef40-54f5-45ef-b706-a4f0706c7102"
+			"22721b42-9410-448f-b8a3-87731847b93f" "24792378-d8a8-475a-8f15-329b96efd879"
+			"251856b5-e6e1-4faf-a3c4-4d92ed48d2ba" "28051639-5fb8-4a04-8103-adff39b5a674"
+			"28aa159c-3b46-48c4-ab5a-d6cd66168db6" "2aa280f1-e689-44aa-9f87-05330cd64611"
+			"2ab1300d-dc8d-42ae-b74e-7b22e5fed7e9" "2bab699d-523f-4fc0-afde-6a31c38bd3fc"
+			"2e6d0dbf-8942-44e7-856d-995ca95f506c" "357c8b7f-8236-4c85-9052-e43b11ab8f77"
+			"35a63585-44c7-4dd2-ac14-c0d7e9024588" "36db8638-730f-48b5-be1d-7830f53b8703"
+			"37b50787-c59d-44de-9b6c-71eeb8fa0a8b" "37ff94e9-cfd2-4b7e-b0be-11347c47b4fe"
+			"3811fe1c-c762-4525-ad28-6cabc3ec09fc" "3ac016a3-18ca-44c6-ab0f-8d9ab5dad40b"
+			"3aca8424-fbff-4d89-b6b1-23e9aae66d68" "3d379a5e-4838-42ac-9849-0acacaf88e22"
+			"3ddb0579-d99d-4b81-95df-b81d20eb97af" "3f301d85-fa84-4c67-aa79-bed2b51f829c"
+			"49d22d72-ae17-4f54-bf57-2fd30ca91cc3" "4e23cdce-bec4-43e6-976a-9576177d66f3"
+			"4f676293-0c89-4b16-a45d-7d5026edb677" "52a755a1-5126-4f2c-8e8a-9f6f69c548c4"
+			"530bc064-c02c-4c44-90c1-c1d28fc38c5b" "53e7b481-d83f-41f2-b5c1-3900f87f714a"
+			"5967c5f8-5b9b-4de8-9474-8329a7e162b7" "5bd8b67a-cef9-476f-9879-e001d391030f"
+			"630a1e73-c4c1-46ce-8b2e-1c117b59b15e" "639794d5-0d67-4b66-893d-533702a3589d"
+			"6511cb94-8ad4-4d06-bfdf-7eb4d5442e85" "66bf39b8-dffd-4931-a026-15c9600aabc1"
+			"6d0f125d-3cf2-4b23-9479-034edfa7d93b" "6e2975c6-d283-4e8a-956d-50ee72c86807"
+			"707e43f8-9f55-4276-b99f-d15b87fb9af9" "7122486a-39ed-416c-b3bf-2ddc99758da3"
+			"72eec5f4-3564-44fc-98e2-7a941b5420c3" "74019e7e-786c-4ed8-9440-d0d616df21af"
+			"7641ea36-2cd3-415f-b8f5-19b168c15b33" "78f51d45-5da4-4189-ba2b-08b1ffd9d128"
+			"798d0c67-45ba-4963-90e9-dd8ee6eec5e3" "7a255f76-1b89-4c7c-8687-3bdc77d67a39"
+			"7f5b3101-5920-453c-a3c5-5b8ec57a1061" "837af8f7-e27e-4504-82a8-da9972e3d94a"
+			"83fb98ca-7210-44b6-b59c-45f60119a7cb" "84f81bff-33ef-407b-a38e-b24595adea2e"
+			"8755c479-fa6b-47b3-845d-57fd8d4e2401" "87c7419d-82a8-4c94-82aa-1397c6f51e49"
+			"87e021be-84cd-4ac3-b017-3b45707a362f" "8987cbdd-2f37-4e24-952a-df94a5597856"
+			"8c3d1587-5e98-468c-9082-5295ca60eac6" "8d714505-4290-4e18-8890-dfef602fb2f6"
+			"8e40d263-bb65-4599-8d39-0356850d2018" "93af5d27-bc1e-4cd8-ac58-90212f08e659"
+			"95328c4a-a9eb-46ef-a096-fbc5b8407e7b" "977d9a05-7ee6-478a-b0a1-553379619b50"
+			"9b8dde13-510a-44cd-92b4-e323843a14f7" "9ccb3918-614d-4835-b181-5e893cfac0c7"
+			"9ff859f0-fd2e-4bc4-8b8c-ccf84857f69d" "a0112e2f-eb91-41d3-a2e0-28f7acd675a1"
+			"a31a4ba2-e983-46fe-b296-8ee88132d070" "a3e561ac-63d5-4acd-9f3e-fa2dfb3760a5"
+			"a5f90c71-2c71-4502-95ca-68363a556090" "ab0ce3af-a4d2-4c11-b132-47020fc90b29"
+			"b1141dcb-165c-4bfe-ad53-629a57d59e32" "b2776448-0f09-427e-a3eb-bb568247929c"
+			"b5d96b2f-b4ea-4c0e-9d13-26bee39fe2bc" "b5f437f1-f289-4dea-b689-99a94ecb57a8"
+			"b637b59c-ee4d-48a4-a91c-962043baa49f" "b7b62ffc-9a9d-4289-ba71-6a43cdd8fe44"
+			"bb069781-cef8-4516-8822-7a0ce2762ca3" "bebde2b3-e370-4358-a67c-f509a2eec055"
+			"c019830a-5f5a-4c37-9e65-dfb50f22f815" "c0b61dcd-b64a-4197-baa0-f81a74af602b"
+			"c30759ed-9b15-497e-b891-70f0b6c3ad75" "c3949f21-22f6-4f96-8b56-f5f5cf0fdf52"
+			"c82fb37d-c27c-4b68-a968-bbf96274d859" "c85ec428-cb05-404a-af3d-b80d32788f75"
+			"c8667fee-cf31-47e1-bc4b-abf45d6dc46d" "c8a104d8-79ff-4872-8e8f-d82aa9cbedfe"
+			"c9ef9015-89e0-4e7b-82c8-74196372535c" "cb8512d4-87f8-4574-8699-0db4fbbedf68"
+			"ccc1faae-5452-406f-8680-177d129c5b22" "cde831a6-1d90-4e9e-a80d-c6f94439fc5e"
+			"ce460634-bb8e-4e89-bf35-3957cfabf094" "d461e650-a856-410d-be79-96569b1c77c5"
+			"d6ea827b-8cf3-48d1-a07e-76c362eda1d4" "d90437ad-7ccb-425b-b162-4505f0c6049d"
+			"d927aa6c-236d-4350-b4a2-1880fdc26b45" "da69f97d-cc71-4ad3-bbab-7a5b5a2f6b47"
+			"db4e24da-73aa-47bb-86b9-4a7acf81252f" "e225242a-aee0-40b3-9f7a-26eca0bfd664"
+			"e56f20d1-8d49-4f94-b494-50f3a84a1e3e" "e7e0d876-5d14-4d4d-995a-3e6399ef4d56"
+			"e98ecbe2-50f5-4e71-b85d-bb13885f76f9" "ec8ea5b9-29a8-40d6-bf56-9b990eb87550"
+			"edfb54ca-e2c1-4b3b-b4de-56880422d129" "ee6fe94a-200e-4cfb-bc55-38ebe82c335f"
+			"f16c3617-1061-45b4-8117-664e6cb87e95" "f5ca5c39-47da-4ead-8a39-9a0ba497901c"
+			"f8602c4c-824e-45de-a52e-17ea5fc6ac69" "f873cc56-7fb2-462b-ab8f-0264541bd686"
+			"f9059593-0cca-44e6-a013-c8f57f8aa5cf"
+		)
+	)
 	(group "group-boardCharacteristics"
 		(uuid "51db034e-ef12-4fff-86dc-7cd091a6a92f")
 		(members "00d7e651-ea74-46a4-b595-b4e97c4d52a7" "11299156-8c6c-446a-a92d-b25f966f7f48"
@@ -35807,79 +35708,6 @@
 			"e9a941cd-8bce-4e5d-abfa-e55f1b58e0d2" "ec00afd1-533b-43ef-883b-0fdc54c7183f"
 			"ec1685a8-471d-4ef5-8be0-9ce07ae8cbce" "efbf361c-9a57-4615-971c-a2a8fdbdfb51"
 			"fe88a9fb-56c8-42e4-92e6-56f4a1b47dc3"
-		)
-	)
-	(group "group-boardStackUp"
-		(uuid "986afa5f-6a66-4d3c-b34a-230015d5a3f9")
-		(members "0243041f-40a9-4173-ae08-bb090d14b2ac" "026e4953-b8a6-4cab-a449-c42431eaeeb3"
-			"0478b8a5-440b-4979-aa81-3b14f62dec32" "04bd0d60-61d1-4887-870e-a639782e347a"
-			"07623b12-f460-44ad-a2ad-6a07e68b57df" "07f46266-6e57-4493-bd72-f078c1f387cf"
-			"088b8579-8766-4d06-8720-9488352bf119" "0a97649d-7857-4076-8e7b-006b21a27ab8"
-			"0bd47c98-664c-4ac6-ae24-fe116c85bd27" "0bdb43ef-db9e-4cfc-be2f-69651f74a460"
-			"0d2f41e3-caca-43ec-ab2f-cf2d2594eb68" "0e800c8b-7a00-4f40-9dfa-9e9b8f30aa75"
-			"0f3024a5-04b8-4e5c-96ba-da03d33d2a93" "1023b904-ecec-4f87-b5d0-ffa841e35817"
-			"109631b9-8300-4a17-ab40-0dc10082d174" "10ee5e6e-c75e-41ce-81e4-364a72b5d947"
-			"15fe9c30-9110-490c-bbdb-bcbb849ca7c0" "18cbf9f1-b535-4845-a317-0206a073816d"
-			"1abc9ecf-3c8c-4dd8-932f-927b65cae9a8" "1af0ff19-e2e4-4244-9cae-0bcc2d691598"
-			"1c71c70b-1f76-4cfa-8002-3bf4dbb0809e" "1ea03baf-6738-4f24-ba19-3112afbe94a6"
-			"1fc6bb38-9de2-45db-a6db-95681683aa09" "22e914a9-c574-4879-a701-1a21c5eebb71"
-			"26853140-84e7-4e4f-a61d-84516fcd80a2" "26b63799-d94a-4efc-b866-4adca38d6dab"
-			"285f1a3c-95ed-46d9-aa60-afaf9ad34b2b" "2a68127a-c35b-4b13-b7fe-fd8ebd34985b"
-			"2ba0321c-c7b9-493e-a5a4-35fd7804af1e" "2d0a7acf-e40b-4796-b1da-d9fe187f6585"
-			"2d322b47-d4bb-447a-a23f-740395ca373b" "2ffe51d2-ca96-495c-a608-0f955837ad44"
-			"3034f5b6-60e2-4774-a381-2f5a2207e1db" "32b19890-8d5c-431b-bac4-3e751850825c"
-			"338be079-d41e-4fbb-b61c-0121d7ca9246" "356fbac4-af33-4639-87e1-0ac0db1fef1c"
-			"3a38d5f3-35ba-40a4-b7c7-708547f2973f" "3b5455ee-1569-4033-b52f-47c54e5e2508"
-			"3bafd540-9743-4676-9196-d1f5118494bb" "3d2be988-7636-436e-89b5-73dc79244fbf"
-			"40a5ac27-9802-44dc-a313-4bf55bb4309f" "40c4191a-75be-4632-8d4e-bba861e0e0cc"
-			"43c45b96-adca-4aa6-915b-751fff33cb2c" "484c232e-5c6e-4b54-98b5-252209a1830f"
-			"4c3cefdb-c597-4a66-92ff-4e790545c70b" "4f468c77-cdcf-4e6d-8761-38373e78b4fd"
-			"4fb4b91d-f1f7-40d0-b52b-661ed597e937" "516be622-de0d-4468-a7fb-046631593f8c"
-			"51a4cda3-d8e6-4eab-9180-5e6f956ad8b1" "5210621b-af0e-4883-856d-d9921d880ff1"
-			"54dacf2d-44db-4faf-9b2e-5f21e9c25c1b" "54fd2a9e-0b2c-482c-af0d-555111cf6421"
-			"55c3b507-6624-4cb0-a7fe-d83b3ae70495" "564ef8a8-b67c-4ab7-b60b-df91757de4ba"
-			"57647177-6356-4de2-ab84-a017c394941e" "58e2d06c-2bc7-4287-8275-75fb09670dcf"
-			"59923e04-0f66-4498-bfbf-8342cb6bd4f5" "60849fe7-e4af-40c5-aae1-af4e120b28e8"
-			"6503b76f-da23-438f-8731-7a07a3f007fc" "67644962-9e91-4b22-aa67-03c4586a090e"
-			"6d706286-31b1-44e4-a63b-99af9d22f953" "6f5ff140-e0ca-404a-b04b-a60ff9a7a981"
-			"700f5212-e1f6-448e-9033-20aa8ba78641" "7087eb2a-8164-49c0-b170-d02fc65a1f1b"
-			"727e88b0-a654-4c2d-b735-6e790403068e" "73287c96-68a2-4c68-b442-06ee61527051"
-			"7880d1e3-15a1-47f9-9a9b-1988489cdddc" "790d50d7-5b6a-4c8a-97fc-4254f15474f0"
-			"79a64c4a-46b2-4db1-b9dd-f21a94a8df02" "7c3f4dc6-5657-44b8-a450-0f342b216aa6"
-			"7c52a853-46d1-4944-b241-fc042a4e8850" "84366177-7fbf-48fd-b2a5-b8b4e6e56eb0"
-			"845f43eb-5229-4b48-9b72-4a6556516f8a" "864b6671-aa20-400d-83e4-2d586a3879b7"
-			"8ac5d2c4-9f53-422d-8656-93465746b732" "8b449b0f-8ea7-49e2-a83e-199515056624"
-			"8b6834f9-972f-4ba9-bbc6-6ec6670bb7fd" "8b82daa9-f424-4ffb-9ead-acc6db380bc6"
-			"8bf80720-b782-44c5-8b6d-241d65d0ece5" "8fc5d96f-8afc-4093-a569-6dc6fa61145d"
-			"91738504-0570-4ac2-8a73-3a48f3734a47" "924d7ae3-9b4d-4e77-a440-f88a60131934"
-			"93fddf8f-864a-4f74-b24f-f9ce6eae6913" "963b8b01-8759-4516-a27a-8a53eab42ee9"
-			"96c3fab9-8604-4cf2-88f4-b411dfcecae4" "9a078920-6aa7-472d-bfed-3676b4888ba6"
-			"9c79315a-6bdc-4011-b669-30b9137949e3" "a2cec7ec-487a-441e-be7c-ca2f7aa6100a"
-			"a47d0021-cdf5-48ee-bd3b-7200c76394ba" "a5ad1192-68aa-43fb-a0cf-29f37b159dc9"
-			"a6185438-fb6d-4cb0-b528-caad324713f6" "a703c4f4-4f44-490b-8d97-ac1bed571502"
-			"a8202641-0a0f-4dd2-882e-460e2b23e07d" "ac686ce5-69d1-42e3-9d25-a4793a7776da"
-			"afc33a24-8927-4163-92c9-7d354cd4fe0d" "b16f9c6f-5089-4608-a80b-9da97bc30b4b"
-			"b4002845-29b8-4a1b-901c-a20064979814" "b76c58b1-d0dc-4abf-85db-14de33c78140"
-			"b8b70d8d-caa0-4819-a683-810561d9ba99" "bc861206-6c30-434f-9fb0-a42da1833e3a"
-			"bdb4ec99-88bb-4bcd-b0eb-dc3494932974" "c084465d-93d2-45d8-8c54-e03c394291c6"
-			"c1edec57-fc78-45ba-9d86-fcacfc40cb31" "c28f0d9d-af44-4d81-ad66-1f3ed36c959c"
-			"c3440f41-60b8-43f2-92f0-819951d984f9" "c408d91d-83ae-4645-8ac9-331d48437f5d"
-			"c626d458-a2aa-4e48-9ef9-467cb3f260a3" "cb3d5a18-0c3c-4a26-92ad-4174f3cb3d22"
-			"cc4c3278-824a-43b9-87a2-0c17c6c5d6f4" "cdfdf9d1-0ae6-4e26-bc20-dd92c62f05da"
-			"d29ea6ee-0c03-4646-9604-581dc6ac9168" "d2b3e15b-bfef-43be-b694-d2968496aa9b"
-			"d33ad7e7-3182-46e7-a79f-3dbbaee1e3bb" "d44994c8-c225-416c-988f-09b20b88654a"
-			"d504eaaf-4ea6-4e34-ac76-cfed6866cc42" "d685f77f-1d1d-4cb6-8669-04df60a0e9ea"
-			"d7ffad51-0bf0-4d6e-9fe8-312f08f73fb7" "dd193e9e-49c3-470d-b635-c4128ebe2cbc"
-			"e019bc0d-a0a0-43be-8a58-b36019f18c0f" "e10a8425-1038-46cf-817f-8d1943586e8f"
-			"e1b97d7b-dd95-4110-a532-c9d31944cd21" "e3a93dc0-36d9-4730-8067-bae036b8095d"
-			"e5108e22-917a-4e2b-877d-c27f4f53ae94" "e84f91e1-20f9-40f7-ba83-9e24e78d25fa"
-			"ea804705-8ab9-4350-911d-3da219b26bca" "ef6f91b4-e2ba-4b00-86bf-653b9eb88de8"
-			"f17a7afe-5cbd-4659-ba1e-98f05f5ea0fd" "f2a857c8-76e7-4849-8cdc-a5cccf73805a"
-			"f2dea757-c30e-4197-a0e0-30a93e9dad0f" "f541dd92-ecab-4c0a-84ce-1662dbae03fa"
-			"f779ea51-dae1-47de-a326-c62aa010fb1f" "fa47adbc-b798-4adf-85ec-2227d619b281"
-			"fb9a9b5f-a4c0-4878-abfe-e61fe631cbf3" "fbc9b37e-d6c1-4d37-85c0-997cbcd64e91"
-			"fc0a2209-c546-4cd5-8d89-2e246a096edb" "ff39d373-15ee-4dca-b0c5-4ffc487efbdd"
-			"ff3a48f2-c25b-4187-b75e-57b705fb1c54"
 		)
 	)
 	(embedded_fonts no)

--- a/ADF4158_PCB.kicad_prl
+++ b/ADF4158_PCB.kicad_prl
@@ -1,6 +1,6 @@
 {
   "board": {
-    "active_layer": 0,
+    "active_layer": 19,
     "active_layer_preset": "",
     "auto_track_width": true,
     "hidden_netclasses": [],

--- a/ADF4158_PCB.kicad_pro
+++ b/ADF4158_PCB.kicad_pro
@@ -38,8 +38,8 @@
         "other_text_upright": false,
         "pads": {
           "drill": 0.0,
-          "height": 0.775,
-          "width": 0.25
+          "height": 0.62,
+          "width": 0.56
         },
         "silk_line_width": 0.1,
         "silk_text_italic": false,
@@ -59,6 +59,10 @@
         }
       ],
       "drc_exclusions": [
+        [
+          "lib_footprint_mismatch|120200000|102000000|a2ab87c3-e138-4768-808f-20b7fd9fd756|00000000-0000-0000-0000-000000000000",
+          ""
+        ],
         [
           "lib_footprint_mismatch|170180000|101080000|9782ee48-7ac2-47b4-9230-4e5cd51b0932|00000000-0000-0000-0000-000000000000",
           ""
@@ -194,8 +198,8 @@
       ],
       "track_widths": [
         0.0,
-        0.4,
-        0.5906
+        0.3658,
+        0.4
       ],
       "tuning_pattern_settings": {
         "diff_pair_defaults": {

--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ The PCB is intended to be fabricated on [JLCPCB](https://jlcpcb.com/) using the
 following options:
 
 - Base material: FR-4
-- Layers: 2
+- Layers: 4
 - Deburring/Edge rounding: Yes
-- PCB thickness: 0.6 mm (50 ohm RF traces are designed for this stack up)
-- Surface finish: LeadFree HASL (HASL with lead is not available with 0.6 mm PCB)
+- PCB thickness: 1.6 mm
+- Material type: FR4-Standard TG 135-140
+- Surface finish: HASL (with lead)
+- Outer copper weight: 1 oz
+- Inner copper weight: 0.5 oz
+- Specify stackup: yes
+- Layer stackup: JLC04161H-7628 (50 ohm RF traces are designed for this stack up)
+- Via covering: plugged
 - Min via hole size/diamager: 0.3 mm (0.4/0.45 mm)
 
-These options are very inexpensive: $5.80 for qty. 5, $9.00 for qty. 30.
+These options are very inexpensive: $7.10 for qty. 5, $13.20 for qty. 10.


### PR DESCRIPTION
Unfortunately the 2116D stackup that I used to get 50 ohm traces of approximately 0.6 mm now costs a huge amount. Use instead the 7628 stackup, which is JLCPCB's cheap/default/recommended stackup. This gives 0.3658 mm 50 ohm traces, which is not ideal for matching with 0402 parts.

![stackup](https://github.com/user-attachments/assets/3ddcb40b-316f-4f74-9f83-8b19b4b70f64)

![impedance](https://github.com/user-attachments/assets/516ba493-507c-4c32-91b1-b96eaa32fbcf)
